### PR TITLE
30 seitenwechsel bei den datapoints funktioniert nicht

### DIFF
--- a/gui/src/stores/datapoints.js
+++ b/gui/src/stores/datapoints.js
@@ -26,19 +26,14 @@ export const useDatapointStore = defineStore('datapoints', () => {
   }
 
   async function search(params) {
-    const reqParams = { ...params, size: params.size ?? 50, page: params.page ?? 0 }
-    console.log('[store.search] request params:', JSON.stringify(reqParams))
     loading.value = true
     try {
-      const { data } = await searchApi.search(reqParams)
-      console.log('[store.search] response: page=', data.page, 'pages=', data.pages, 'total=', data.total, 'items=', data.items.length)
+      const { data } = await searchApi.search({ ...params, size: params.size ?? 50, page: params.page ?? 0 })
       items.value = data.items
       total.value = data.total
       page.value  = data.page
       size.value  = data.size
       pages.value = data.pages
-    } catch (err) {
-      console.error('[store.search] error:', err)
     } finally {
       loading.value = false
     }

--- a/gui/src/views/DataPointsView.vue
+++ b/gui/src/views/DataPointsView.vue
@@ -126,18 +126,15 @@ watch(() => store.items, (items) => {
 }, { immediate: true })
 
 function onSearch() {
-  console.log('[onSearch] triggered, filters:', JSON.stringify(filters.value))
   clearTimeout(searchTimeout)
   searchTimeout = setTimeout(() => {
     const { q, tag, type } = filters.value
-    console.log('[onSearch] debounce fired, filters:', JSON.stringify(filters.value))
     if (q || tag || type) store.search({ q, tag, type })
     else store.fetchPage(0)
   }, 350)
 }
 
 function goPage(p) {
-  console.log('[goPage] p=', p, 'store.page=', store.page, 'store.pages=', store.pages, 'filters:', JSON.stringify(filters.value))
   const { q, tag, type } = filters.value
   store.search({ q, tag, type, page: p })
 }

--- a/opentws/adapters/knx/adapter.py
+++ b/opentws/adapters/knx/adapter.py
@@ -218,7 +218,7 @@ class KnxAdapter(AdapterBase):
                     quality = "good"
                 except Exception as exc:
                     logger.warning("KNX DPT decode error for %s (%s): %s", ga, dpt.dpt_id, exc)
-                    value = raw
+                    value = raw.hex() if isinstance(raw, (bytes, bytearray)) else raw
                     quality = "uncertain"
 
                 logger.info("KNX value: GA=%s → dp=%s value=%s", ga, binding.datapoint_id, value)

--- a/opentws/api/v1/datapoints.py
+++ b/opentws/api/v1/datapoints.py
@@ -14,7 +14,7 @@ import uuid
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from pydantic import BaseModel
+from pydantic import BaseModel, field_serializer
 
 from opentws.api.auth import get_current_user
 from opentws.core.registry import get_registry
@@ -42,6 +42,12 @@ class DataPointOut(BaseModel):
     quality: str | None = None
 
     model_config = {"from_attributes": True}
+
+    @field_serializer("value")
+    def _serialize_value(self, v: Any) -> Any:
+        if isinstance(v, (bytes, bytearray)):
+            return v.hex()
+        return v
 
 
 class DataPointPage(BaseModel):


### PR DESCRIPTION
Root Cause: Der KNX-Adapter speichert bei einem DPT-Decode-Fehler den rohen Telegrem-bytes-Wert (value = raw). Diese bytes-Objekte sind nicht JSON-serialisierbar — FastAPI crasht beim Serialisieren der Response für alle DataPoints ab Position 50 (page 1+). Page 0 funktionierte zufällig, weil die ersten 50 DataPoints keine solchen Roh-Bytes-Werte hatten.

Fixes:

KNX-Adapter (adapter.py:221): Bei Decode-Fehler jetzt raw.hex() statt raw
DataPointOut (datapoints.py): Defensiver field_serializer der bytes → hex konvertiert, für alle zukünftigen Fälle