### PR TITLE
fix(websocket): fix webservice crash caused by non-JSON-serialisable …

### DIFF
--- a/opentws/adapters/knx/dpt_registry.py
+++ b/opentws/adapters/knx/dpt_registry.py
@@ -335,7 +335,7 @@ _UNKNOWN_DPT = DPTDefinition(
     unit="",
     size_bytes=0,
     encoder=lambda v: v if isinstance(v, bytes) else str(v).encode(),
-    decoder=lambda b: b,
+    decoder=lambda b: b.hex(),  # hex string is JSON-serialisable; raw bytes are not
 )
 
 

--- a/opentws/api/v1/websocket.py
+++ b/opentws/api/v1/websocket.py
@@ -71,8 +71,10 @@ class WebSocketManager:
     async def _send(self, conn_id: str, msg: dict) -> bool:
         """Send *msg* to one connection, serialised via its per-connection lock.
 
-        Returns True on success, False if the send failed (caller should
-        disconnect the client so it can reconnect cleanly).
+        Returns True on success, False if the WebSocket itself is broken (caller
+        should disconnect so the client can reconnect cleanly).
+        Serialisation errors (e.g. non-JSON-serialisable value) are logged and
+        the message is dropped — they do NOT close the connection.
         """
         entry = self._connections.get(conn_id)
         if entry is None:
@@ -82,7 +84,13 @@ class WebSocketManager:
             try:
                 await ws.send_json(msg)
                 return True
+            except (TypeError, ValueError) as exc:
+                # The message itself cannot be serialised — log and drop it,
+                # but keep the WebSocket open.
+                logger.error("WS send skipped — message not JSON-serialisable: %s", exc)
+                return True
             except Exception:
+                # Actual transport error — signal caller to close the connection.
                 return False
 
     async def broadcast(self, msg: dict) -> None:


### PR DESCRIPTION
…bytes value from unknown KNX DPT

_UNKNOWN_DPT.decoder returned raw bytes which caused json.dumps to raise TypeError in the WebSocket broadcast, disconnecting all clients. The GUI's 5-second reconnect timer then produced the reported "5sec live / 5sec offline" cycle.

- dpt_registry: decoder now returns b.hex() (JSON-safe hex string)
- websocket: _send() logs serialisation errors and keeps the connection open instead of silently closing it

Closes #34