### PR TITLE
Add persist_value flag for DataPoints with DB migration

### DIFF
--- a/gui/src/components/datapoints/DataPointForm.vue
+++ b/gui/src/components/datapoints/DataPointForm.vue
@@ -42,6 +42,11 @@
       <input v-model="form.mqtt_alias" type="text" class="input" placeholder="alias/eg/wohnzimmer/temperatur/value" />
     </div>
 
+    <label class="flex items-center gap-2 cursor-pointer select-none">
+      <input v-model="form.persist_value" type="checkbox" class="w-4 h-4 rounded accent-blue-500" />
+      <span class="text-sm text-slate-700 dark:text-slate-200">Letzten Wert speichern <span class="text-slate-500 font-normal">(nach Neustart sofort verfügbar)</span></span>
+    </label>
+
     <div v-if="error" class="p-3 bg-red-500/10 border border-red-500/30 rounded-lg text-sm text-red-400">
       {{ error }}
     </div>
@@ -138,9 +143,10 @@ const effectiveUnit = computed(() => {
 })
 
 const form = reactive({
-  name:       '',
-  data_type:  'FLOAT',
-  mqtt_alias: '',
+  name:          '',
+  data_type:     'FLOAT',
+  mqtt_alias:    '',
+  persist_value: true,
 })
 
 // Helper: initialise unit controls from a raw string
@@ -160,13 +166,15 @@ function applyUnit(raw) {
 
 watch(() => props.initial, (val) => {
   if (val) {
-    form.name       = val.name
-    form.data_type  = val.data_type
-    form.mqtt_alias = val.mqtt_alias ?? ''
-    tagsInput.value = val.tags?.join(', ') ?? ''
+    form.name          = val.name
+    form.data_type     = val.data_type
+    form.mqtt_alias    = val.mqtt_alias ?? ''
+    form.persist_value = val.persist_value ?? true
+    tagsInput.value    = val.tags?.join(', ') ?? ''
     applyUnit(val.unit)
   } else {
     form.name = ''; form.data_type = 'FLOAT'; form.mqtt_alias = ''
+    form.persist_value = true
     tagsInput.value = ''
     applyUnit('')
   }
@@ -178,11 +186,12 @@ async function submit() {
   try {
     const tags = tagsInput.value.split(',').map(t => t.trim()).filter(Boolean)
     await props.saveHandler({
-      name:       form.name,
-      data_type:  form.data_type,
-      unit:       effectiveUnit.value,
+      name:          form.name,
+      data_type:     form.data_type,
+      unit:          effectiveUnit.value,
       tags,
-      mqtt_alias: form.mqtt_alias || null,
+      mqtt_alias:    form.mqtt_alias || null,
+      persist_value: form.persist_value,
     })
   } catch (e) {
     error.value = e.response?.data?.detail ?? e.message ?? 'Fehler beim Speichern'

--- a/gui/src/views/DataPointDetailView.vue
+++ b/gui/src/views/DataPointDetailView.vue
@@ -41,6 +41,10 @@
             <Badge v-for="t in dp.tags" :key="t" variant="default" size="xs">{{ t }}</Badge>
             <span v-if="!dp.tags?.length" class="text-slate-500">—</span>
           </dd>
+          <dt class="text-slate-500">Wert speichern</dt>
+          <dd>
+            <Badge :variant="dp.persist_value ? 'success' : 'muted'" size="xs">{{ dp.persist_value ? 'Ja' : 'Nein' }}</Badge>
+          </dd>
           <dt class="text-slate-500">Erstellt</dt>   <dd class="text-slate-400 text-xs">{{ new Date(dp.created_at).toLocaleString('de-CH') }}</dd>
           <dt class="text-slate-500">Geändert</dt>   <dd class="text-slate-400 text-xs">{{ new Date(dp.updated_at).toLocaleString('de-CH') }}</dd>
         </dl>

--- a/opentws/api/v1/datapoints.py
+++ b/opentws/api/v1/datapoints.py
@@ -35,6 +35,7 @@ class DataPointOut(BaseModel):
     tags: list[str]
     mqtt_topic: str
     mqtt_alias: str | None
+    persist_value: bool
     created_at: str
     updated_at: str
     # Runtime
@@ -82,6 +83,7 @@ def _enrich(dp: Any) -> DataPointOut:
         tags=dp.tags,
         mqtt_topic=dp.mqtt_topic,
         mqtt_alias=dp.mqtt_alias,
+        persist_value=dp.persist_value,
         created_at=dp.created_at.isoformat(),
         updated_at=dp.updated_at.isoformat(),
         value=state.value if state else None,

--- a/opentws/core/registry.py
+++ b/opentws/core/registry.py
@@ -86,6 +86,32 @@ class DataPointRegistry:
             self._points[dp.id] = dp
             self._values[dp.id] = ValueState()
         logger.info("DataPointRegistry: loaded %d datapoints from DB", len(self._points))
+
+        # Restore persisted last values (quality = "good" per spec)
+        persisted = await self._db.fetchall("SELECT * FROM datapoint_last_values")
+        restored = 0
+        for row in persisted:
+            dp_id = uuid.UUID(row["datapoint_id"])
+            state = self._values.get(dp_id)
+            dp = self._points.get(dp_id)
+            if state is None or dp is None or not dp.persist_value:
+                continue
+            try:
+                import json as _json
+                value = _json.loads(row["value"])
+            except Exception:
+                value = row["value"]
+            state.value = value
+            state.quality = "good"
+            from datetime import datetime, timezone
+            try:
+                state.ts = datetime.fromisoformat(row["ts"])
+            except Exception:
+                state.ts = datetime.now(timezone.utc)
+            restored += 1
+        if restored:
+            logger.info("DataPointRegistry: restored %d persisted values", restored)
+
         return len(self._points)
 
     # ------------------------------------------------------------------
@@ -142,11 +168,12 @@ class DataPointRegistry:
         dp = DataPoint(**payload.model_dump())
         await self._db.execute_and_commit(
             """INSERT INTO datapoints
-               (id, name, data_type, unit, tags, mqtt_topic, mqtt_alias, created_at, updated_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+               (id, name, data_type, unit, tags, mqtt_topic, mqtt_alias, persist_value, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 str(dp.id), dp.name, dp.data_type, dp.unit,
                 json.dumps(dp.tags), dp.mqtt_topic, dp.mqtt_alias,
+                int(dp.persist_value),
                 dp.created_at.isoformat(), dp.updated_at.isoformat(),
             ),
         )
@@ -166,14 +193,21 @@ class DataPointRegistry:
 
         await self._db.execute_and_commit(
             """UPDATE datapoints
-               SET name=?, data_type=?, unit=?, tags=?, mqtt_alias=?, updated_at=?
+               SET name=?, data_type=?, unit=?, tags=?, mqtt_alias=?, persist_value=?, updated_at=?
                WHERE id=?""",
             (
                 dp.name, dp.data_type, dp.unit,
                 json.dumps(dp.tags), dp.mqtt_alias,
+                int(dp.persist_value),
                 now.isoformat(), str(dp_id),
             ),
         )
+        # If persistence was just disabled, remove any stored last value
+        if not dp.persist_value:
+            await self._db.execute_and_commit(
+                "DELETE FROM datapoint_last_values WHERE datapoint_id=?", (str(dp_id),)
+            )
+
         self._points[dp_id] = dp
         logger.debug("DataPoint updated: %s (%s)", dp.name, dp_id)
         return dp
@@ -203,6 +237,23 @@ class DataPointRegistry:
         state = self._values[event.datapoint_id]
         changed = state.update(event.value, event.quality)
 
+        # Persist last value to DB if enabled
+        if dp.persist_value and event.quality == "good":
+            await self._db.execute_and_commit(
+                """INSERT INTO datapoint_last_values (datapoint_id, value, unit, ts)
+                   VALUES (?, ?, ?, ?)
+                   ON CONFLICT(datapoint_id) DO UPDATE SET
+                       value=excluded.value,
+                       unit=excluded.unit,
+                       ts=excluded.ts""",
+                (
+                    str(dp.id),
+                    json.dumps(event.value),
+                    dp.unit,
+                    event.ts.isoformat(),
+                ),
+            )
+
         # Publish to MQTT on every event (alias only on value change)
         alias_topic = dp.mqtt_alias if changed else None
         await self._mqtt.publish_value(
@@ -225,6 +276,7 @@ def _row_to_datapoint(row: Any) -> DataPoint:
         tags=json.loads(row["tags"]),
         mqtt_topic=row["mqtt_topic"],
         mqtt_alias=row["mqtt_alias"],
+        persist_value=bool(row["persist_value"]) if row["persist_value"] is not None else True,
         created_at=datetime.fromisoformat(row["created_at"]),
         updated_at=datetime.fromisoformat(row["updated_at"]),
     )

--- a/opentws/db/database.py
+++ b/opentws/db/database.py
@@ -230,6 +230,17 @@ _MIGRATION_V14 = """
 ALTER TABLE logic_graphs ADD COLUMN node_state TEXT NOT NULL DEFAULT '{}';
 """
 
+_MIGRATION_V15 = """
+ALTER TABLE datapoints ADD COLUMN persist_value INTEGER NOT NULL DEFAULT 1;
+
+CREATE TABLE IF NOT EXISTS datapoint_last_values (
+    datapoint_id  TEXT PRIMARY KEY REFERENCES datapoints(id) ON DELETE CASCADE,
+    value         TEXT NOT NULL,
+    unit          TEXT,
+    ts            TEXT NOT NULL
+);
+"""
+
 # List of (version, sql_or_callable) tuples — append new migrations here
 MIGRATIONS: list[tuple[int, str | Callable]] = [
     (1, _MIGRATION_V1),
@@ -246,6 +257,7 @@ MIGRATIONS: list[tuple[int, str | Callable]] = [
     (12, _MIGRATION_V12),
     (13, _MIGRATION_V13),
     (14, _MIGRATION_V14),
+    (15, _MIGRATION_V15),
 ]
 
 

--- a/opentws/models/datapoint.py
+++ b/opentws/models/datapoint.py
@@ -16,6 +16,7 @@ class DataPoint(BaseModel):
     tags: list[str] = Field(default_factory=list)
     mqtt_topic: str = ""
     mqtt_alias: Optional[str] = None
+    persist_value: bool = True
     created_at: datetime.datetime = Field(
         default_factory=lambda: datetime.datetime.now(datetime.timezone.utc)
     )
@@ -36,6 +37,7 @@ class DataPointCreate(BaseModel):
     unit: Optional[str] = None
     tags: list[str] = Field(default_factory=list)
     mqtt_alias: Optional[str] = None
+    persist_value: bool = True
 
 
 class DataPointUpdate(BaseModel):
@@ -44,3 +46,4 @@ class DataPointUpdate(BaseModel):
     unit: Optional[str] = None
     tags: Optional[list[str]] = None
     mqtt_alias: Optional[str] = None
+    persist_value: Optional[bool] = None


### PR DESCRIPTION
Adds persist_value flag (default: on) to DataPoints. When enabled, the last good value is written to datapoint_last_values on every update and restored on startup with quality=good. DB migration V15 adds the column and the new table.