### PR TITLE
Fix SOURCE-Transformation application in bindings

### DIFF
--- a/opentws/adapters/knx/adapter.py
+++ b/opentws/adapters/knx/adapter.py
@@ -239,6 +239,9 @@ class KnxAdapter(AdapterBase):
                     value = raw.hex() if isinstance(raw, (bytes, bytearray)) else raw
                     quality = "uncertain"
 
+                if binding.value_formula and quality == "good":
+                    from opentws.core.formula import apply_formula
+                    value = apply_formula(binding.value_formula, value)
                 logger.info("KNX value: GA=%s → dp=%s value=%s", ga, binding.datapoint_id, value)
                 await self._bus.publish(DataValueEvent(
                     datapoint_id=binding.datapoint_id,

--- a/opentws/adapters/modbus_rtu/adapter.py
+++ b/opentws/adapters/modbus_rtu/adapter.py
@@ -136,6 +136,9 @@ class ModbusRtuAdapter(AdapterBase):
             try:
                 value = await self._read_register(bc)
                 quality = "good" if value is not None else "bad"
+                if binding.value_formula and quality == "good":
+                    from opentws.core.formula import apply_formula
+                    value = apply_formula(binding.value_formula, value)
                 await self._bus.publish(DataValueEvent(
                     datapoint_id=binding.datapoint_id,
                     value=value,

--- a/opentws/adapters/modbus_tcp/adapter.py
+++ b/opentws/adapters/modbus_tcp/adapter.py
@@ -136,6 +136,9 @@ class ModbusTcpAdapter(AdapterBase):
             try:
                 value = await self._read_register(bc)
                 quality = "good" if value is not None else "bad"
+                if binding.value_formula and quality == "good":
+                    from opentws.core.formula import apply_formula
+                    value = apply_formula(binding.value_formula, value)
                 await self._bus.publish(DataValueEvent(
                     datapoint_id=binding.datapoint_id,
                     value=value,

--- a/opentws/adapters/mqtt/adapter.py
+++ b/opentws/adapters/mqtt/adapter.py
@@ -182,10 +182,14 @@ class MqttAdapter(AdapterBase):
             value = raw
 
         for binding in entries:
-            logger.info("MQTT adapter received: topic=%s → dp=%s value=%r", topic, binding.datapoint_id, value)
+            pub_value = value
+            if binding.value_formula and pub_value is not None:
+                from opentws.core.formula import apply_formula
+                pub_value = apply_formula(binding.value_formula, pub_value)
+            logger.info("MQTT adapter received: topic=%s → dp=%s value=%r", topic, binding.datapoint_id, pub_value)
             await self._bus.publish(DataValueEvent(
                 datapoint_id=binding.datapoint_id,
-                value=value,
+                value=pub_value,
                 quality="good",
                 source_adapter=self.adapter_type,
                 binding_id=binding.id,

--- a/opentws/adapters/onewire/adapter.py
+++ b/opentws/adapters/onewire/adapter.py
@@ -129,6 +129,9 @@ class OneWireAdapter(AdapterBase):
                     None, _read_sensor_file, Path(self._cfg.w1_path) / bc.sensor_id
                 )
                 quality = "good" if value is not None else "bad"
+                if binding.value_formula and quality == "good":
+                    from opentws.core.formula import apply_formula
+                    value = apply_formula(binding.value_formula, value)
                 await self._bus.publish(DataValueEvent(
                     datapoint_id=binding.datapoint_id,
                     value=value,

--- a/opentws/core/write_router.py
+++ b/opentws/core/write_router.py
@@ -78,22 +78,8 @@ class WriteRouter:
             "WriteRouter.handle_value_event: dp=%s value=%r source_binding=%s",
             event.datapoint_id, event.value, event.binding_id,
         )
-        # SOURCE-Formel: Wert des empfangenden Bindings transformieren
-        value = event.value
-        if event.binding_id:
-            src_row = await self._db.fetchone(
-                "SELECT value_formula FROM adapter_bindings WHERE id=?",
-                (str(event.binding_id),),
-            )
-            if src_row and src_row["value_formula"]:
-                from opentws.core.formula import apply_formula
-                value = apply_formula(src_row["value_formula"], value)
-                logger.debug(
-                    "WriteRouter: SOURCE formula '%s' applied: %r → %r",
-                    src_row["value_formula"], event.value, value,
-                )
         await self._write_to_dest_bindings(
-            event.datapoint_id, value, skip_binding_id=event.binding_id
+            event.datapoint_id, event.value, skip_binding_id=event.binding_id
         )
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
Wert-Formel bei SOURCE-Bindings wird jetzt direkt im Adapter angewandt, bevor das DataValueEvent veroeffentlicht wird. Dadurch erhalten alle Konsumenten (Registry, MQTT, WebSocket, RingBuffer, WriteRouter) den bereits transformierten Wert. Zuvor wurde die Formel nur im WriteRouter fuer DEST-Routing verwendet, nicht aber fuer den gespeicherten DP-Wert.