### PR TITLE
fix(knx): DPT10/DPT11 decode returns ISO string instead of datetime.t…

### DIFF
--- a/opentws/adapters/knx/dpt_registry.py
+++ b/opentws/adapters/knx/dpt_registry.py
@@ -209,16 +209,16 @@ def _dpt3_encode(v: Any) -> bytes:
 # --- DPT 10.x — Time of Day (3 bytes) ----------------------------------------
 # Byte0: DoW(7..5)|Hour(4..0)  Byte1: Minutes(5..0)  Byte2: Seconds(5..0)
 # DoW: 1=Mon…7=Sun, 0=any day
-# Rückgabe als datetime.time
-def _dpt10_decode(b: bytes) -> "datetime.time":
+# Rückgabe als ISO-String "HH:MM:SS" (JSON-serialisierbar)
+def _dpt10_decode(b: bytes) -> str:
     import datetime
     try:
         hour   = b[0] & 0x1F
         minute = b[1] & 0x3F
         second = b[2] & 0x3F
-        return datetime.time(hour, minute, second)
+        return datetime.time(hour, minute, second).isoformat()
     except Exception:
-        return datetime.time(0, 0, 0)
+        return "00:00:00"
 
 def _dpt10_encode(v: Any) -> bytes:
     import datetime
@@ -240,17 +240,17 @@ def _dpt10_encode(v: Any) -> bytes:
 # --- DPT 11.x — Date (3 bytes) -----------------------------------------------
 # Byte0: Day(4..0)  Byte1: Month(3..0)  Byte2: Year(6..0)
 # Jahr 0..89 → 2000+Y,  Jahr 90..99 → 1900+Y  (KNX-Spec)
-# Rückgabe als datetime.date
-def _dpt11_decode(b: bytes) -> "datetime.date":
+# Rückgabe als ISO-String "YYYY-MM-DD" (JSON-serialisierbar)
+def _dpt11_decode(b: bytes) -> str:
     import datetime
     try:
         day   = b[0] & 0x1F
         month = b[1] & 0x0F
         yr    = b[2] & 0x7F
         year  = 2000 + yr if yr < 90 else 1900 + yr
-        return datetime.date(year, month, day)
+        return datetime.date(year, month, day).isoformat()
     except Exception:
-        return datetime.date(2000, 1, 1)
+        return "2000-01-01"
 
 def _dpt11_encode(v: Any) -> bytes:
     import datetime


### PR DESCRIPTION
…ime/date

Fixes 'Object of type time is not JSON serializable' errors in history factory, WebSocket API, and RingBuffer when processing DPT10.x / DPT11.x telegrams.

Closes #79