### PR TITLE
fix(#212): Objekt-Filter lädt alle DataPoints statt nur 500

### DIFF
--- a/gui/src/api/client.js
+++ b/gui/src/api/client.js
@@ -65,7 +65,18 @@ export const authApi = {
 // ── DataPoints ────────────────────────────────────────────────────────────
 export const dpApi = {
   list:          (page = 0, size = 50, sort = 'created_at', order = 'asc') => api.get('/datapoints/', { params: { page, size, sort, order } }),
-  listAll:       ()                             => api.get('/datapoints/', { params: { page: 0, size: 500, sort: 'name', order: 'asc' } }),
+  listAll: async () => {
+    const size = 500
+    const first = await api.get('/datapoints/', { params: { page: 0, size, sort: 'name', order: 'asc' } })
+    const { items, pages } = first.data
+    if (pages <= 1) return { data: { items } }
+    const rest = await Promise.all(
+      Array.from({ length: pages - 1 }, (_, i) =>
+        api.get('/datapoints/', { params: { page: i + 1, size, sort: 'name', order: 'asc' } })
+      )
+    )
+    return { data: { items: [...items, ...rest.flatMap(r => r.data.items)] } }
+  },
   get:           (id)                           => api.get(`/datapoints/${id}`),
   create:        (data)                         => api.post('/datapoints/', data),
   update:        (id, data)                     => api.patch(`/datapoints/${id}`, data),

--- a/obs/api/v1/datapoints.py
+++ b/obs/api/v1/datapoints.py
@@ -115,7 +115,7 @@ _SORT_KEYS = {
 @router.get("/", response_model=DataPointPage)
 async def list_datapoints(
     page:  int = Query(0, ge=0),
-    size:  int = Query(50, ge=1, le=500),
+    size:  int = Query(50, ge=1, le=10000),
     sort:  str = Query("created_at", pattern="^(name|data_type|created_at|updated_at)$"),
     order: str = Query("asc",        pattern="^(asc|desc)$"),
     _user: str = Depends(get_current_user),

--- a/tests/gui/admin/history-filter.spec.ts
+++ b/tests/gui/admin/history-filter.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-import { apiPost, apiDelete } from '../helpers'
+import { apiGet, apiPost, apiDelete } from '../helpers'
 
 // ---------------------------------------------------------------------------
 // Helper: PATCH DataPoint via API
@@ -183,5 +183,41 @@ test('Objekt-Filter Suche filtert Objekte korrekt', async ({ page }) => {
       apiDelete(`/api/v1/datapoints/${dpA.id}`),
       apiDelete(`/api/v1/datapoints/${dpB.id}`),
     ])
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Test 5: Objekt-Filter — Zähler stimmt mit tatsächlicher Gesamtzahl überein
+// (Regression für Bug #212: nur 500 Objekte wurden angezeigt)
+// ---------------------------------------------------------------------------
+
+test('Objekt-Filter zeigt alle Objekte — Zähler entspricht API-Gesamtzahl', async ({ page }) => {
+  const BASE_URL = process.env.BASE_URL ?? 'http://localhost:8080'
+
+  // Gesamtzahl vor dem Test ermitteln
+  const before = await apiGet('/api/v1/datapoints/?page=0&size=1') as { total: number }
+  const totalBefore = before.total
+
+  // 3 neue Objekte anlegen, damit mindestens diese im Filter erscheinen müssen
+  const names = Array.from({ length: 3 }, (_, i) => `E2E-CountCheck-${Date.now()}-${i}`)
+  const created = await Promise.all(
+    names.map(name => apiPost('/api/v1/datapoints', { name, data_type: 'FLOAT', tags: [] }) as Promise<{ id: string }>)
+  )
+  const expectedTotal = totalBefore + 3
+
+  try {
+    await openHistoryFilterTab(page)
+
+    // Der Zähler "X von Y Objekt(e) ausgeschlossen" muss Y = expectedTotal zeigen
+    const counterText = page.locator('[data-testid="history-filter-card"] .card-header span')
+    await expect(counterText).toContainText(`von ${expectedTotal} Objekt`, { timeout: 8_000 })
+
+    // Alle 3 neu erstellten Objekte müssen einzeln auffindbar sein
+    for (const dp of created) {
+      await page.fill('[data-testid="input-history-filter-search"]', dp.id)
+      await expect(page.locator(`[data-testid="toggle-history-${dp.id}"]`)).toBeVisible({ timeout: 8_000 })
+    }
+  } finally {
+    await Promise.all(created.map(dp => apiDelete(`/api/v1/datapoints/${dp.id}`)))
   }
 })

--- a/tests/integration/test_datapoints.py
+++ b/tests/integration/test_datapoints.py
@@ -118,6 +118,57 @@ async def test_pagination_limits_results(client, auth_headers):
     assert body["size"] == 2
 
 
+async def test_list_size_above_500_accepted(client, auth_headers):
+    """size-Parameter darf jetzt bis 10000 gehen (Bug #212: vorher nur bis 500)."""
+    resp = await client.get(
+        "/api/v1/datapoints/",
+        params={"page": 0, "size": 1000},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["size"] == 1000
+
+
+async def test_list_size_above_10000_rejected(client, auth_headers):
+    """size > 10000 muss mit 422 abgelehnt werden."""
+    resp = await client.get(
+        "/api/v1/datapoints/",
+        params={"page": 0, "size": 10001},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 422
+
+
+async def test_pagination_covers_all_items(client, auth_headers):
+    """Mehrseitige Abfrage (size=2) liefert zusammen alle Objekte."""
+    for i in range(5):
+        await _create_dp(client, auth_headers, {**_DP_PAYLOAD, "name": f"AllItems-DP-{i}"})
+
+    # Erstes Mal: Gesamtzahl ermitteln
+    first = await client.get(
+        "/api/v1/datapoints/",
+        params={"page": 0, "size": 2},
+        headers=auth_headers,
+    )
+    body = first.json()
+    total = body["total"]
+    pages = body["pages"]
+    assert total >= 5
+
+    # Alle Seiten abrufen und IDs sammeln
+    all_ids: set[str] = set()
+    for p in range(pages):
+        resp = await client.get(
+            "/api/v1/datapoints/",
+            params={"page": p, "size": 2},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        all_ids.update(item["id"] for item in resp.json()["items"])
+
+    assert len(all_ids) == total
+
+
 # ---------------------------------------------------------------------------
 # Update
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- Backend: size-Limit im list_datapoints-Endpoint von 500 auf 10000 erhöht
- Frontend: dpApi.listAll() paginiert jetzt automatisch alle Seiten (à 500 Objekte) und gibt erst dann alle Objekte zusammen zurück — kein Abschneiden mehr
- Tests: 3 neue Backend-Integration-Tests (size > 500 erlaubt, > 10000 abgelehnt, mehrseitige Abfrage liefert alle Objekte)
- E2E: Neuer Playwright-Test prüft, dass der Zähler im Historisierung-Filter mit der tatsächlichen API-Gesamtzahl übereinstimmt (Regression-Test für #212)