### PR TITLE
Implement iFrame widget for embedding external websites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Alle wesentlichen Änderungen an open bridge server werden hier festgehalten.
 
 ### Neu
 
+**Visu — iFrame-Widget**
+- Neues Widget zum Einbetten externer Webseiten direkt in die Visualisierung
+- Konfigurierbar: URL, Bezeichnung, Sandbox-Berechtigungen (Checkboxen), Vollbildmodus, Seitenverhältnis (16:9, 4:3, 1:1, Frei)
+- Sandbox-Attribut schützt vor ungewollter Interaktion des eingebetteten Inhalts; Berechtigungen werden einzeln aktiviert
+- Sicherheitshinweis in der Konfiguration erinnert daran, nur vertrauenswürdige URLs einzubetten
+- Im Editor-Modus: Overlay verhindert Klick-Interaktion, Platzhalter wenn keine URL konfiguriert
+
 **RingBuffer — Live-Aktualisierung über WebSocket**
 - Neue Einträge werden sofort an alle geöffneten Browser übertragen — kein manuelles Neuladen mehr nötig
 - Status-Badge „Live" / „Offline" zeigt den Verbindungszustand an

--- a/frontend/src/views/VisuEditor.vue
+++ b/frontend/src/views/VisuEditor.vue
@@ -50,6 +50,7 @@ import '@/widgets/Fenster/index'
 import '@/widgets/Energiefluss/index'
 import '@/widgets/Kamera/index'
 import '@/widgets/QrCode/index'
+import '@/widgets/IFrame/index'
 
 // ── Props / Router / Store ────────────────────────────────────────────────────
 const props = defineProps<{ id: string }>()

--- a/frontend/src/views/VisuViewer.vue
+++ b/frontend/src/views/VisuViewer.vue
@@ -28,6 +28,7 @@ import '@/widgets/Fenster/index'
 import '@/widgets/Energiefluss/index'
 import '@/widgets/Kamera/index'
 import '@/widgets/QrCode/index'
+import '@/widgets/IFrame/index'
 
 const props = defineProps<{ id: string }>()
 const router = useRouter()

--- a/frontend/src/widgets/IFrame/Config.vue
+++ b/frontend/src/widgets/IFrame/Config.vue
@@ -1,0 +1,143 @@
+<script setup lang="ts">
+import { reactive, watch, computed } from 'vue'
+
+const props = defineProps<{
+  modelValue: Record<string, unknown>
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', val: Record<string, unknown>): void
+}>()
+
+const cfg = reactive({
+  label:           (props.modelValue.label           as string)  ?? '',
+  url:             (props.modelValue.url             as string)  ?? '',
+  sandbox:         (props.modelValue.sandbox         as string)  ?? 'allow-same-origin allow-scripts allow-popups allow-forms',
+  allowFullscreen: (props.modelValue.allowFullscreen as boolean) ?? false,
+  aspectRatio:     (props.modelValue.aspectRatio     as string)  ?? '16/9',
+})
+
+watch(() => props.modelValue, (v) => {
+  cfg.label           = (v.label           as string)  ?? ''
+  cfg.url             = (v.url             as string)  ?? ''
+  cfg.sandbox         = (v.sandbox         as string)  ?? 'allow-same-origin allow-scripts allow-popups allow-forms'
+  cfg.allowFullscreen = (v.allowFullscreen as boolean) ?? false
+  cfg.aspectRatio     = (v.aspectRatio     as string)  ?? '16/9'
+})
+
+watch(cfg, () => emit('update:modelValue', { ...cfg }), { deep: true })
+
+const SANDBOX_OPTIONS = [
+  { key: 'allow-same-origin',              label: 'Same-Origin (Cookies, localStorage)' },
+  { key: 'allow-scripts',                  label: 'Skripte (JavaScript)' },
+  { key: 'allow-popups',                   label: 'Popups & Links' },
+  { key: 'allow-forms',                    label: 'Formulare' },
+  { key: 'allow-popups-to-escape-sandbox', label: 'Popups aus Sandbox entlassen' },
+  { key: 'allow-top-navigation-by-user-activation', label: 'Navigation (nur bei Nutzerinteraktion)' },
+]
+
+function hasSandbox(key: string): boolean {
+  return cfg.sandbox.split(' ').includes(key)
+}
+
+function toggleSandbox(key: string) {
+  const parts = cfg.sandbox ? cfg.sandbox.split(' ').filter(Boolean) : []
+  const idx = parts.indexOf(key)
+  if (idx >= 0) parts.splice(idx, 1)
+  else parts.push(key)
+  cfg.sandbox = parts.join(' ')
+}
+
+const ASPECT_RATIOS = [
+  { value: '16/9', label: '16:9' },
+  { value: '4/3',  label: '4:3'  },
+  { value: '1/1',  label: '1:1'  },
+  { value: 'free', label: 'Frei (Höhe füllen)' },
+]
+
+const isValidUrl = computed(() => {
+  if (!cfg.url) return true
+  try { new URL(cfg.url); return true } catch { return false }
+})
+</script>
+
+<template>
+  <div class="space-y-3">
+
+    <!-- Bezeichnung -->
+    <div>
+      <label class="block text-xs text-gray-400 mb-1">Bezeichnung</label>
+      <input
+        v-model="cfg.label"
+        type="text"
+        placeholder="z.B. Wetterkarte, Kalender …"
+        class="w-full bg-gray-800 border border-gray-700 rounded px-2 py-1.5 text-sm text-gray-100 focus:outline-none focus:border-blue-500"
+      />
+    </div>
+
+    <!-- URL -->
+    <div>
+      <label class="block text-xs text-gray-400 mb-1">URL</label>
+      <input
+        v-model="cfg.url"
+        type="url"
+        placeholder="https://example.com"
+        class="w-full bg-gray-800 border rounded px-2 py-1.5 text-sm text-gray-100 focus:outline-none focus:border-blue-500"
+        :class="isValidUrl ? 'border-gray-700' : 'border-red-500'"
+      />
+      <p v-if="!isValidUrl" class="mt-1 text-xs text-red-400">Ungültige URL</p>
+    </div>
+
+    <!-- Seitenverhältnis -->
+    <div>
+      <label class="block text-xs text-gray-400 mb-1">Seitenverhältnis</label>
+      <select
+        v-model="cfg.aspectRatio"
+        class="w-full bg-gray-800 border border-gray-700 rounded px-2 py-1.5 text-sm text-gray-100 focus:outline-none focus:border-blue-500"
+      >
+        <option v-for="ar in ASPECT_RATIOS" :key="ar.value" :value="ar.value">{{ ar.label }}</option>
+      </select>
+    </div>
+
+    <!-- Sandbox-Berechtigungen -->
+    <div>
+      <label class="block text-xs text-gray-400 mb-2">Sandbox-Berechtigungen</label>
+      <div class="space-y-1.5">
+        <label
+          v-for="opt in SANDBOX_OPTIONS"
+          :key="opt.key"
+          class="flex items-center gap-2 cursor-pointer"
+        >
+          <input
+            type="checkbox"
+            :checked="hasSandbox(opt.key)"
+            class="accent-blue-500"
+            @change="toggleSandbox(opt.key)"
+          />
+          <span class="text-xs text-gray-300">{{ opt.label }}</span>
+        </label>
+      </div>
+    </div>
+
+    <!-- Vollbild -->
+    <div>
+      <label class="flex items-center gap-2 cursor-pointer">
+        <input
+          v-model="cfg.allowFullscreen"
+          type="checkbox"
+          class="accent-blue-500"
+        />
+        <span class="text-xs text-gray-300">Vollbildmodus erlauben</span>
+      </label>
+    </div>
+
+    <!-- Sicherheitshinweis -->
+    <div class="rounded bg-yellow-900/30 border border-yellow-700/50 px-3 py-2">
+      <p class="text-xs text-yellow-300">
+        Nur vertrauenswürdige URLs einbetten. Sandbox-Berechtigungen erhöhen den Funktionsumfang,
+        jedoch auch das Sicherheitsrisiko.
+      </p>
+    </div>
+
+  </div>
+</template>

--- a/frontend/src/widgets/IFrame/Widget.vue
+++ b/frontend/src/widgets/IFrame/Widget.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { DataPointValue } from '@/types'
+
+const props = defineProps<{
+  config: Record<string, unknown>
+  datapointId: string | null
+  value: DataPointValue | null
+  statusValue: DataPointValue | null
+  editorMode: boolean
+}>()
+
+const label           = computed(() => (props.config.label           as string)  ?? '')
+const url             = computed(() => (props.config.url             as string)  ?? '')
+const sandbox         = computed(() => (props.config.sandbox         as string)  ?? '')
+const allowFullscreen = computed(() => (props.config.allowFullscreen as boolean) ?? false)
+const aspectRatio     = computed(() => (props.config.aspectRatio     as string)  ?? '16/9')
+
+const containerStyle = computed((): Record<string, string> => {
+  if (aspectRatio.value === 'free') return {}
+  return { aspectRatio: aspectRatio.value }
+})
+</script>
+
+<template>
+  <div class="h-full w-full flex flex-col overflow-hidden rounded">
+
+    <!-- Label -->
+    <div
+      v-if="label"
+      class="shrink-0 px-2 py-1 text-xs text-gray-300 bg-gray-900/80 truncate"
+    >
+      {{ label }}
+    </div>
+
+    <!-- Editor-Platzhalter -->
+    <div
+      v-if="editorMode && !url"
+      class="flex-1 flex flex-col items-center justify-center text-gray-500 gap-2 bg-gray-800/40"
+    >
+      <span class="text-4xl">🖼️</span>
+      <span class="text-xs">URL konfigurieren</span>
+    </div>
+
+    <!-- Kein URL im Live-Modus -->
+    <div
+      v-else-if="!url"
+      class="flex-1 flex items-center justify-center text-gray-600 text-xs bg-gray-900"
+    >
+      Keine URL konfiguriert
+    </div>
+
+    <!-- iFrame -->
+    <div
+      v-else
+      class="flex-1 relative overflow-hidden"
+      :style="containerStyle"
+    >
+      <!-- Overlay im Editor-Modus verhindert Interaktion mit dem iFrame -->
+      <div
+        v-if="editorMode"
+        class="absolute inset-0 z-10 cursor-default"
+      />
+      <iframe
+        :src="url"
+        :sandbox="sandbox || undefined"
+        :allowfullscreen="allowFullscreen || undefined"
+        referrerpolicy="no-referrer"
+        class="w-full h-full border-0"
+        title="iFrame"
+        data-testid="iframe-element"
+      />
+    </div>
+
+  </div>
+</template>

--- a/frontend/src/widgets/IFrame/index.ts
+++ b/frontend/src/widgets/IFrame/index.ts
@@ -1,0 +1,22 @@
+import { WidgetRegistry } from '@/widgets/registry'
+import Widget from './Widget.vue'
+import Config from './Config.vue'
+
+WidgetRegistry.register({
+  type: 'IFrame',
+  label: 'iFrame',
+  icon: '🖼️',
+  minW: 3, minH: 2,
+  defaultW: 6, defaultH: 4,
+  component: Widget,
+  configComponent: Config,
+  defaultConfig: {
+    label: '',
+    url: '',
+    sandbox: 'allow-same-origin allow-scripts allow-popups allow-forms',
+    allowFullscreen: false,
+    aspectRatio: '16/9',
+  },
+  compatibleTypes: ['*'],
+  noDatapoint: true,
+})

--- a/tests/gui/visu/iframe.spec.ts
+++ b/tests/gui/visu/iframe.spec.ts
@@ -1,0 +1,200 @@
+import { test, expect } from '@playwright/test'
+import { randomUUID } from 'crypto'
+import { apiPost, apiPut, apiDelete } from '../helpers'
+
+/**
+ * E2E-Tests für das iFrame-Widget.
+ *
+ * Priorität hoch:
+ *   1. Kein URL konfiguriert → Platzhalter "Keine URL konfiguriert"
+ *   2. URL konfiguriert → <iframe> mit korrektem src-Attribut
+ *   3. Sandbox-Attribut wird korrekt gesetzt
+ *   4. allowfullscreen-Attribut bei aktiviertem Vollbild
+ *
+ * Priorität mittel:
+ *   5. Label-Text wird in der Kopfzeile angezeigt
+ *   6. Kein sandbox-Attribut wenn Sandbox-String leer
+ */
+
+async function createVisuPage() {
+  return await apiPost('/api/v1/visu/nodes', {
+    name: `E2E-IFrame-Page-${Date.now()}`,
+    type: 'PAGE',
+    order: 999,
+    access: 'public',
+  }) as { id: string }
+}
+
+async function buildIFramePage(
+  pageId: string,
+  widgetId: string,
+  config: Record<string, unknown>,
+) {
+  await apiPut(`/api/v1/visu/pages/${pageId}`, {
+    grid_cols: 12,
+    grid_row_height: 80,
+    grid_cell_width: 80,
+    background: null,
+    widgets: [
+      {
+        id: widgetId,
+        name: 'E2E iFrame',
+        type: 'IFrame',
+        datapoint_id: null,
+        status_datapoint_id: null,
+        x: 0, y: 0, w: 6, h: 4,
+        config,
+      },
+    ],
+  })
+}
+
+// ─── Test 1 (hoch): Kein URL → Platzhalter ───────────────────────────────────
+
+test('iFrame: kein URL konfiguriert → Platzhalter "Keine URL konfiguriert"', async ({ page }) => {
+  const visuNode = await createVisuPage()
+  const pageId   = visuNode.id
+  const widgetId = randomUUID()
+
+  await buildIFramePage(pageId, widgetId, { label: '', url: '' })
+
+  try {
+    await page.goto(`/visu/${pageId}`)
+    await page.waitForLoadState('domcontentloaded')
+
+    const widget = page.locator(`[data-widget-id="${widgetId}"]`)
+    await expect(widget).toContainText('Keine URL konfiguriert')
+    await expect(widget.locator('iframe')).toHaveCount(0)
+  } finally {
+    await apiDelete(`/api/v1/visu/nodes/${pageId}`)
+  }
+})
+
+// ─── Test 2 (hoch): URL gesetzt → <iframe> mit korrektem src ─────────────────
+
+test('iFrame: URL konfiguriert → <iframe> mit korrektem src-Attribut', async ({ page }) => {
+  const visuNode = await createVisuPage()
+  const pageId   = visuNode.id
+  const widgetId = randomUUID()
+  const frameUrl = 'https://example.com'
+
+  await buildIFramePage(pageId, widgetId, {
+    url: frameUrl,
+    sandbox: 'allow-same-origin allow-scripts',
+    allowFullscreen: false,
+  })
+
+  try {
+    await page.goto(`/visu/${pageId}`)
+    await page.waitForLoadState('domcontentloaded')
+
+    const iframe = page.locator(`[data-widget-id="${widgetId}"] iframe`)
+    await expect(iframe).toBeAttached({ timeout: 10_000 })
+    await expect(iframe).toHaveAttribute('src', frameUrl)
+  } finally {
+    await apiDelete(`/api/v1/visu/nodes/${pageId}`)
+  }
+})
+
+// ─── Test 3 (hoch): Sandbox-Attribut gesetzt ─────────────────────────────────
+
+test('iFrame: Sandbox-Permissions werden als sandbox-Attribut am <iframe> gesetzt', async ({ page }) => {
+  const visuNode = await createVisuPage()
+  const pageId   = visuNode.id
+  const widgetId = randomUUID()
+  const sandbox  = 'allow-same-origin allow-scripts allow-popups'
+
+  await buildIFramePage(pageId, widgetId, {
+    url: 'https://example.com',
+    sandbox,
+    allowFullscreen: false,
+  })
+
+  try {
+    await page.goto(`/visu/${pageId}`)
+    await page.waitForLoadState('domcontentloaded')
+
+    const iframe = page.locator(`[data-widget-id="${widgetId}"] iframe`)
+    await expect(iframe).toBeAttached({ timeout: 10_000 })
+    await expect(iframe).toHaveAttribute('sandbox', sandbox)
+  } finally {
+    await apiDelete(`/api/v1/visu/nodes/${pageId}`)
+  }
+})
+
+// ─── Test 4 (hoch): allowfullscreen-Attribut ─────────────────────────────────
+
+test('iFrame: allowFullscreen=true → allowfullscreen-Attribut am <iframe> vorhanden', async ({ page }) => {
+  const visuNode = await createVisuPage()
+  const pageId   = visuNode.id
+  const widgetId = randomUUID()
+
+  await buildIFramePage(pageId, widgetId, {
+    url: 'https://example.com',
+    sandbox: 'allow-same-origin allow-scripts',
+    allowFullscreen: true,
+  })
+
+  try {
+    await page.goto(`/visu/${pageId}`)
+    await page.waitForLoadState('domcontentloaded')
+
+    const iframe = page.locator(`[data-widget-id="${widgetId}"] iframe`)
+    await expect(iframe).toBeAttached({ timeout: 10_000 })
+    // allowfullscreen ist ein Boolean-Attribut – prüfen dass es gesetzt ist
+    const val = await iframe.getAttribute('allowfullscreen')
+    expect(val).not.toBeNull()
+  } finally {
+    await apiDelete(`/api/v1/visu/nodes/${pageId}`)
+  }
+})
+
+// ─── Test 5 (mittel): Label-Text ─────────────────────────────────────────────
+
+test('iFrame: konfiguriertes Label wird in Kopfzeile angezeigt', async ({ page }) => {
+  const visuNode = await createVisuPage()
+  const pageId   = visuNode.id
+  const widgetId = randomUUID()
+
+  await buildIFramePage(pageId, widgetId, {
+    label: 'Mein Dashboard',
+    url: 'https://example.com',
+    sandbox: 'allow-same-origin allow-scripts',
+  })
+
+  try {
+    await page.goto(`/visu/${pageId}`)
+    await page.waitForLoadState('domcontentloaded')
+
+    const widget = page.locator(`[data-widget-id="${widgetId}"]`)
+    await expect(widget).toContainText('Mein Dashboard')
+  } finally {
+    await apiDelete(`/api/v1/visu/nodes/${pageId}`)
+  }
+})
+
+// ─── Test 6 (mittel): Leerer Sandbox-String → kein sandbox-Attribut ──────────
+
+test('iFrame: leerer Sandbox-String → kein sandbox-Attribut am <iframe>', async ({ page }) => {
+  const visuNode = await createVisuPage()
+  const pageId   = visuNode.id
+  const widgetId = randomUUID()
+
+  await buildIFramePage(pageId, widgetId, {
+    url: 'https://example.com',
+    sandbox: '',
+    allowFullscreen: false,
+  })
+
+  try {
+    await page.goto(`/visu/${pageId}`)
+    await page.waitForLoadState('domcontentloaded')
+
+    const iframe = page.locator(`[data-widget-id="${widgetId}"] iframe`)
+    await expect(iframe).toBeAttached({ timeout: 10_000 })
+    const sandboxVal = await iframe.getAttribute('sandbox')
+    expect(sandboxVal).toBeNull()
+  } finally {
+    await apiDelete(`/api/v1/visu/nodes/${pageId}`)
+  }
+})


### PR DESCRIPTION
Neues Widget zum Einbetten externer Webseiten in die Visualisierung. Konfigurierbar: URL, Bezeichnung, Sandbox-Berechtigungen (Checkboxen), Vollbildmodus und Seitenverhältnis. Inkl. 6 Playwright E2E-Tests.