### PR TITLE
feat: Uhr-Widget mit Analog-, Digital- und Wortuhr-Modus (Issue #167)

### DIFF
--- a/frontend/src/views/VisuEditor.vue
+++ b/frontend/src/views/VisuEditor.vue
@@ -51,6 +51,7 @@ import '@/widgets/Energiefluss/index'
 import '@/widgets/Kamera/index'
 import '@/widgets/QrCode/index'
 import '@/widgets/IFrame/index'
+import '@/widgets/Uhr/index'
 
 // ── Props / Router / Store ────────────────────────────────────────────────────
 const props = defineProps<{ id: string }>()

--- a/frontend/src/views/VisuViewer.vue
+++ b/frontend/src/views/VisuViewer.vue
@@ -29,6 +29,7 @@ import '@/widgets/Energiefluss/index'
 import '@/widgets/Kamera/index'
 import '@/widgets/QrCode/index'
 import '@/widgets/IFrame/index'
+import '@/widgets/Uhr/index'
 
 const props = defineProps<{ id: string }>()
 const router = useRouter()

--- a/frontend/src/widgets/Uhr/Config.vue
+++ b/frontend/src/widgets/Uhr/Config.vue
@@ -1,0 +1,109 @@
+<script setup lang="ts">
+import { reactive, watch } from 'vue'
+
+type UhrModus = 'digital' | 'analog' | 'wortuhr'
+
+interface UhrConfig {
+  mode:        UhrModus
+  showSeconds: boolean
+  showDate:    boolean
+  color:       string
+  label:       string
+}
+
+const MODI: { value: UhrModus; label: string }[] = [
+  { value: 'digital', label: 'Digital' },
+  { value: 'analog',  label: 'Analog'  },
+  { value: 'wortuhr', label: 'Wortuhr' },
+]
+
+const props = defineProps<{ modelValue: Record<string, unknown> }>()
+const emit  = defineEmits<{ (e: 'update:modelValue', val: Record<string, unknown>): void }>()
+
+const cfg = reactive<UhrConfig>({
+  mode:        (props.modelValue.mode        as UhrModus | undefined) ?? 'digital',
+  showSeconds: (props.modelValue.showSeconds as boolean  | undefined) ?? false,
+  showDate:    (props.modelValue.showDate    as boolean  | undefined) ?? false,
+  color:       (props.modelValue.color       as string   | undefined) ?? '#3b82f6',
+  label:       (props.modelValue.label       as string   | undefined) ?? '',
+})
+
+watch(cfg, () => emit('update:modelValue', { ...cfg }), { deep: true })
+</script>
+
+<template>
+  <div class="space-y-4 text-sm">
+
+    <!-- Modus -->
+    <div>
+      <label class="block text-xs text-gray-400 mb-1">Modus</label>
+      <div class="flex gap-1">
+        <button
+          v-for="m in MODI"
+          :key="m.value"
+          type="button"
+          :class="[
+            'flex-1 py-1.5 text-xs rounded border transition-colors',
+            cfg.mode === m.value
+              ? 'border-blue-500 bg-blue-500/20 text-blue-300'
+              : 'border-gray-700 text-gray-400 hover:border-gray-500',
+          ]"
+          @click="cfg.mode = m.value"
+        >{{ m.label }}</button>
+      </div>
+    </div>
+
+    <!-- Farbe -->
+    <div>
+      <label class="block text-xs text-gray-400 mb-1">Akzentfarbe</label>
+      <div class="flex items-center gap-2">
+        <input
+          v-model="cfg.color"
+          type="color"
+          class="w-8 h-8 rounded cursor-pointer border border-gray-700 bg-transparent p-0.5 shrink-0"
+          title="Akzentfarbe"
+        />
+        <span class="text-xs text-gray-500 font-mono">{{ cfg.color }}</span>
+      </div>
+    </div>
+
+    <!-- Sekunden anzeigen (analog + digital) -->
+    <div v-if="cfg.mode !== 'wortuhr'">
+      <label class="flex items-center gap-2 cursor-pointer select-none">
+        <input
+          v-model="cfg.showSeconds"
+          type="checkbox"
+          class="w-4 h-4 rounded accent-blue-500"
+        />
+        <span class="text-xs text-gray-300">Sekunden anzeigen</span>
+      </label>
+    </div>
+
+    <!-- Datum anzeigen (nur digital) -->
+    <div v-if="cfg.mode === 'digital'">
+      <label class="flex items-center gap-2 cursor-pointer select-none">
+        <input
+          v-model="cfg.showDate"
+          type="checkbox"
+          class="w-4 h-4 rounded accent-blue-500"
+        />
+        <span class="text-xs text-gray-300">Datum anzeigen</span>
+      </label>
+    </div>
+
+    <!-- Beschriftung -->
+    <div>
+      <label class="block text-xs text-gray-400 mb-1">
+        Beschriftung
+        <span class="text-gray-600 font-normal ml-1">(optional)</span>
+      </label>
+      <input
+        v-model="cfg.label"
+        type="text"
+        placeholder="z.B. Wohnzimmer"
+        class="w-full bg-gray-800 border border-gray-700 rounded px-2 py-1.5 text-sm text-gray-100 focus:outline-none focus:border-blue-500"
+      />
+    </div>
+
+  </div>
+</template>

--- a/frontend/src/widgets/Uhr/Widget.vue
+++ b/frontend/src/widgets/Uhr/Widget.vue
@@ -1,0 +1,322 @@
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref } from 'vue'
+import type { DataPointValue } from '@/types'
+
+const props = defineProps<{
+  config: Record<string, unknown>
+  datapointId: string | null
+  value: DataPointValue | null
+  statusValue: DataPointValue | null
+  editorMode: boolean
+}>()
+
+// ── Konfiguration ─────────────────────────────────────────────────────────────
+const mode        = computed(() => (props.config.mode        as string  | undefined) ?? 'digital')
+const showSeconds = computed(() => (props.config.showSeconds as boolean | undefined) ?? false)
+const showDate    = computed(() => (props.config.showDate    as boolean | undefined) ?? false)
+const color       = computed(() => (props.config.color       as string  | undefined) ?? '#3b82f6')
+const label       = computed(() => (props.config.label       as string  | undefined) ?? '')
+
+// ── Live-Zeit ─────────────────────────────────────────────────────────────────
+const now = ref(new Date())
+let timer: ReturnType<typeof setInterval> | null = null
+
+onMounted(() => {
+  timer = setInterval(() => { now.value = new Date() }, 1000)
+})
+onUnmounted(() => {
+  if (timer !== null) clearInterval(timer)
+})
+
+// ── Digital ───────────────────────────────────────────────────────────────────
+const timeStr = computed(() => {
+  const d  = now.value
+  const hh = String(d.getHours()).padStart(2, '0')
+  const mm = String(d.getMinutes()).padStart(2, '0')
+  const ss = String(d.getSeconds()).padStart(2, '0')
+  return showSeconds.value ? `${hh}:${mm}:${ss}` : `${hh}:${mm}`
+})
+
+const dateStr = computed(() =>
+  now.value.toLocaleDateString('de-CH', {
+    weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
+  }),
+)
+
+// ── Analog ────────────────────────────────────────────────────────────────────
+const hourDeg   = computed(() => {
+  const d = now.value
+  return (d.getHours() % 12) * 30 + d.getMinutes() * 0.5
+})
+const minuteDeg = computed(() => now.value.getMinutes() * 6)
+const secondDeg = computed(() => now.value.getSeconds() * 6)
+
+// ── Wortuhr ───────────────────────────────────────────────────────────────────
+/**
+ * 11×10 Buchstabenraster für die deutsche Wortuhr.
+ *
+ * Zeile 0 : E S K I S T L F Ü N F
+ * Zeile 1 : Z E H N Z W A N Z I G
+ * Zeile 2 : D R E I V I E R T E L
+ * Zeile 3 : T G N A C H V O R J M
+ * Zeile 4 : H A L B Q Z W Ö L F P
+ * Zeile 5 : Z W E I N S D R E I X
+ * Zeile 6 : V I E R S I E B E N A
+ * Zeile 7 : A C H T Z E H N E L F
+ * Zeile 8 : N E U N F Ü N F S E C
+ * Zeile 9 : H S S E C H S U H R A
+ */
+const GRID: string[][] = [
+  ['E','S','K','I','S','T','L','F','Ü','N','F'],
+  ['Z','E','H','N','Z','W','A','N','Z','I','G'],
+  ['D','R','E','I','V','I','E','R','T','E','L'],
+  ['T','G','N','A','C','H','V','O','R','J','M'],
+  ['H','A','L','B','Q','Z','W','Ö','L','F','P'],
+  ['Z','W','E','I','N','S','D','R','E','I','X'],
+  ['V','I','E','R','S','I','E','B','E','N','A'],
+  ['A','C','H','T','Z','E','H','N','E','L','F'],
+  ['N','E','U','N','F','Ü','N','F','S','E','C'],
+  ['H','S','S','E','C','H','S','U','H','R','A'],
+]
+
+// [wortSchlüssel, zeile, startSpalte, länge]
+const WORT_DEFINITIONEN: [string, number, number, number][] = [
+  ['ES',          0,  0, 2],
+  ['IST',         0,  3, 3],
+  ['FÜNF_MIN',    0,  7, 4],   // FÜNF (Minuten)
+  ['ZEHN_MIN',    1,  0, 4],   // ZEHN (Minuten)
+  ['ZWANZIG',     1,  4, 7],
+  ['DREIVIERTEL', 2,  0, 11],  // gesamte Zeile
+  ['VIERTEL',     2,  4, 7],
+  ['NACH',        3,  2, 4],
+  ['VOR',         3,  6, 3],
+  ['HALB',        4,  0, 4],
+  ['H12',         4,  5, 5],   // ZWÖLF
+  ['H1',          5,  2, 3],   // EIN (gemeinsame Buchstaben mit ZWEI)
+  ['H2',          5,  0, 4],   // ZWEI
+  ['H3',          5,  6, 4],   // DREI
+  ['H4',          6,  0, 4],   // VIER
+  ['H7',          6,  4, 6],   // SIEBEN
+  ['H8',          7,  0, 4],   // ACHT
+  ['H10',         7,  4, 4],   // ZEHN
+  ['H11',         7,  8, 3],   // ELF
+  ['H9',          8,  0, 4],   // NEUN
+  ['H5',          8,  4, 4],   // FÜNF (Stunde)
+  ['H6',          9,  2, 5],   // SECHS
+  ['UHR',         9,  7, 3],
+]
+
+// Vorberechnung: welche Wörter decken jede Zelle ab?
+const ZELLEN_WÖRTER: string[][][] = GRID.map(row => row.map(() => [] as string[]))
+for (const [schlüssel, zeile, spalte, länge] of WORT_DEFINITIONEN) {
+  for (let s = spalte; s < spalte + länge; s++) {
+    ZELLEN_WÖRTER[zeile][s].push(schlüssel)
+  }
+}
+
+function getAktiveWörter(stunden: number, minuten: number): Set<string> {
+  const aktiv = new Set<string>(['ES', 'IST'])
+
+  let gerundeteMinuten = Math.round(minuten / 5) * 5
+
+  // 24h → 12h
+  let h = stunden % 12
+  if (h === 0) h = 12
+
+  // Überlauf (z.B. 57 min → gerundet 60)
+  const überlauf = gerundeteMinuten >= 60
+  if (überlauf) gerundeteMinuten = 0
+
+  // Ab 25 Minuten zeigen wir die nächste Stunde an
+  const nächsteStunde = gerundeteMinuten >= 25 || überlauf
+  let anzeigeStunde = nächsteStunde ? (h % 12) + 1 : h
+  if (anzeigeStunde > 12) anzeigeStunde = 1
+
+  switch (gerundeteMinuten) {
+    case  0: aktiv.add('UHR'); break
+    case  5: aktiv.add('FÜNF_MIN'); aktiv.add('NACH'); break
+    case 10: aktiv.add('ZEHN_MIN'); aktiv.add('NACH'); break
+    case 15: aktiv.add('VIERTEL');  aktiv.add('NACH'); break
+    case 20: aktiv.add('ZWANZIG');  aktiv.add('NACH'); break
+    case 25: aktiv.add('FÜNF_MIN'); aktiv.add('VOR');  aktiv.add('HALB'); break
+    case 30: aktiv.add('HALB'); break
+    case 35: aktiv.add('FÜNF_MIN'); aktiv.add('NACH'); aktiv.add('HALB'); break
+    case 40: aktiv.add('ZWANZIG');  aktiv.add('VOR');  break
+    case 45: aktiv.add('DREIVIERTEL'); break
+    case 50: aktiv.add('ZEHN_MIN'); aktiv.add('VOR'); break
+    case 55: aktiv.add('FÜNF_MIN'); aktiv.add('VOR'); break
+  }
+
+  aktiv.add(`H${anzeigeStunde}`)
+  return aktiv
+}
+
+const aktiveWörter = computed(() =>
+  getAktiveWörter(now.value.getHours(), now.value.getMinutes()),
+)
+
+function istZelleAktiv(zeile: number, spalte: number): boolean {
+  return ZELLEN_WÖRTER[zeile][spalte].some(k => aktiveWörter.value.has(k))
+}
+</script>
+
+<template>
+  <div
+    class="h-full w-full flex flex-col items-center justify-center select-none overflow-hidden"
+    style="container-type: inline-size;"
+    data-testid="uhr-widget"
+  >
+
+    <!-- ═══════════════════════════════════════ DIGITAL ═══ -->
+    <template v-if="mode === 'digital'">
+      <div class="flex flex-col items-center justify-center gap-1 w-full px-3">
+        <span
+          data-testid="uhr-digital-time"
+          class="font-mono font-bold tabular-nums leading-none w-full text-center"
+          style="font-size: clamp(1.4rem, 15cqi, 5rem);"
+          :style="{ color }"
+        >{{ timeStr }}</span>
+
+        <span
+          v-if="showDate"
+          data-testid="uhr-digital-date"
+          class="text-gray-400 dark:text-gray-500 text-center w-full leading-tight"
+          style="font-size: clamp(0.55rem, 3cqi, 0.9rem);"
+        >{{ dateStr }}</span>
+
+        <span
+          v-if="label"
+          class="text-gray-500 dark:text-gray-400 text-center"
+          style="font-size: clamp(0.5rem, 2.5cqi, 0.8rem);"
+        >{{ label }}</span>
+      </div>
+    </template>
+
+    <!-- ═══════════════════════════════════════ ANALOG ════ -->
+    <template v-else-if="mode === 'analog'">
+      <div class="flex flex-col items-center justify-center w-full h-full px-2 py-2 gap-1">
+        <svg
+          data-testid="uhr-analog"
+          viewBox="0 0 100 100"
+          class="w-full h-full"
+          :style="label ? 'max-height: calc(100% - 1.4rem)' : 'max-height: 100%'"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <!-- Zifferblatt-Ring -->
+          <circle
+            cx="50" cy="50" r="48"
+            fill="none"
+            class="stroke-gray-200 dark:stroke-gray-700"
+            stroke-width="1.5"
+          />
+
+          <!-- Stundenmarkierungen -->
+          <g v-for="i in 12" :key="`hmark-${i}`">
+            <line
+              :x1="50 + 40 * Math.sin((i * 30) * Math.PI / 180)"
+              :y1="50 - 40 * Math.cos((i * 30) * Math.PI / 180)"
+              :x2="50 + 45 * Math.sin((i * 30) * Math.PI / 180)"
+              :y2="50 - 45 * Math.cos((i * 30) * Math.PI / 180)"
+              class="stroke-gray-400 dark:stroke-gray-500"
+              stroke-width="2"
+              stroke-linecap="round"
+            />
+          </g>
+
+          <!-- Minutenmarkierungen (kleine Punkte) -->
+          <g v-for="i in 60" :key="`mmark-${i}`">
+            <line
+              v-if="i % 5 !== 0"
+              :x1="50 + 43 * Math.sin((i * 6) * Math.PI / 180)"
+              :y1="50 - 43 * Math.cos((i * 6) * Math.PI / 180)"
+              :x2="50 + 46 * Math.sin((i * 6) * Math.PI / 180)"
+              :y2="50 - 46 * Math.cos((i * 6) * Math.PI / 180)"
+              class="stroke-gray-300 dark:stroke-gray-600"
+              stroke-width="0.7"
+              stroke-linecap="round"
+            />
+          </g>
+
+          <!-- Stundenzeiger -->
+          <line
+            :transform="`rotate(${hourDeg}, 50, 50)`"
+            x1="50" y1="50"
+            x2="50" y2="23"
+            stroke-width="3.5"
+            stroke-linecap="round"
+            :stroke="color"
+          />
+
+          <!-- Minutenzeiger -->
+          <line
+            :transform="`rotate(${minuteDeg}, 50, 50)`"
+            x1="50" y1="52"
+            x2="50" y2="12"
+            stroke-width="2.5"
+            stroke-linecap="round"
+            class="stroke-gray-100 dark:stroke-gray-200"
+          />
+
+          <!-- Sekundenzeiger -->
+          <line
+            v-if="showSeconds"
+            :transform="`rotate(${secondDeg}, 50, 50)`"
+            x1="50" y1="58"
+            x2="50" y2="9"
+            stroke-width="1"
+            stroke-linecap="round"
+            stroke="#ef4444"
+          />
+
+          <!-- Mittelachse -->
+          <circle cx="50" cy="50" r="3" :fill="color" />
+          <circle v-if="showSeconds" cx="50" cy="50" r="1.5" fill="#ef4444" />
+        </svg>
+
+        <span
+          v-if="label"
+          class="text-gray-500 dark:text-gray-400 text-xs text-center w-full truncate leading-none"
+        >{{ label }}</span>
+      </div>
+    </template>
+
+    <!-- ═══════════════════════════════════════ WORTUHR ═══ -->
+    <template v-else-if="mode === 'wortuhr'">
+      <div
+        data-testid="uhr-wortuhr"
+        class="w-full h-full flex flex-col items-center justify-center p-1"
+      >
+        <!-- Buchstabenraster 11 × 10 -->
+        <div
+          class="grid w-full"
+          style="
+            grid-template-columns: repeat(11, 1fr);
+            grid-template-rows: repeat(10, 1fr);
+            flex: 1;
+            min-height: 0;
+          "
+        >
+          <template v-for="(zeile, zi) in GRID" :key="zi">
+            <div
+              v-for="(buchstabe, si) in zeile"
+              :key="`${zi}-${si}`"
+              class="flex items-center justify-center font-bold uppercase transition-colors duration-300 leading-none"
+              style="font-size: clamp(0.35rem, 6cqi, 1rem);"
+              :style="istZelleAktiv(zi, si) ? { color } : {}"
+              :class="istZelleAktiv(zi, si)
+                ? ''
+                : 'text-gray-300 dark:text-gray-700'"
+            >{{ buchstabe }}</div>
+          </template>
+        </div>
+
+        <span
+          v-if="label"
+          class="text-gray-500 dark:text-gray-400 text-center mt-0.5 shrink-0"
+          style="font-size: clamp(0.5rem, 2.5cqi, 0.75rem);"
+        >{{ label }}</span>
+      </div>
+    </template>
+
+  </div>
+</template>

--- a/frontend/src/widgets/Uhr/index.ts
+++ b/frontend/src/widgets/Uhr/index.ts
@@ -1,0 +1,24 @@
+import { WidgetRegistry } from '@/widgets/registry'
+import Widget from './Widget.vue'
+import Config from './Config.vue'
+
+WidgetRegistry.register({
+  type:    'Uhr',
+  label:   'Uhr',
+  icon:    '🕐',
+  minW:    2,
+  minH:    2,
+  defaultW: 3,
+  defaultH: 3,
+  component:       Widget,
+  configComponent: Config,
+  defaultConfig: {
+    mode:        'digital',
+    showSeconds: false,
+    showDate:    false,
+    color:       '#3b82f6',
+    label:       '',
+  },
+  compatibleTypes: ['*'],
+  noDatapoint:     true,
+})

--- a/tests/gui/visu/uhr.spec.ts
+++ b/tests/gui/visu/uhr.spec.ts
@@ -1,0 +1,237 @@
+import { test, expect } from '@playwright/test'
+import { randomUUID } from 'crypto'
+import { apiPost, apiPut, apiDelete } from '../helpers'
+
+/**
+ * E2E-Tests für das Uhr-Widget (Issue #167).
+ *
+ * Testsuite deckt ab:
+ *   1. Digital-Modus: Widget wird gerendert und zeigt eine gültige Uhrzeit
+ *   2. Digital-Modus mit Sekunden: HH:MM:SS Format sichtbar
+ *   3. Digital-Modus mit Datum: Datum wird unterhalb der Zeit angezeigt
+ *   4. Analog-Modus: SVG-Uhr wird gerendert
+ *   5. Wortuhr-Modus: Buchstabenraster 11×10 wird gerendert, ES und IST sind hervorgehoben
+ *   6. Wortuhr-Modus: Korrekte Wörter für verschiedene Uhrzeiten (gemockt via JS)
+ */
+
+// ─── Hilfsfunktionen ─────────────────────────────────────────────────────────
+
+async function createVisuPage() {
+  return await apiPost('/api/v1/visu/nodes', {
+    name: `E2E-Uhr-Page-${Date.now()}`,
+    type: 'PAGE',
+    order: 999,
+    access: 'public',
+  }) as { id: string }
+}
+
+async function buildUhrPage(
+  pageId: string,
+  widgetId: string,
+  config: Record<string, unknown>,
+) {
+  await apiPut(`/api/v1/visu/pages/${pageId}`, {
+    grid_cols: 12,
+    grid_row_height: 80,
+    grid_cell_width: 80,
+    background: null,
+    widgets: [
+      {
+        id:               widgetId,
+        name:             'E2E Uhr',
+        type:             'Uhr',
+        datapoint_id:     null,
+        status_datapoint_id: null,
+        x: 0, y: 0, w: 4, h: 4,
+        config,
+      },
+    ],
+  })
+}
+
+// ─── Test 1: Digital-Modus – Grunddarstellung ─────────────────────────────────
+
+test('Uhr digital-Modus: Widget rendert und zeigt gültige HH:MM-Zeit', async ({ page }) => {
+  const visuNode = await createVisuPage()
+  const pageId   = visuNode.id
+  const widgetId = randomUUID()
+
+  await buildUhrPage(pageId, widgetId, {
+    mode:        'digital',
+    showSeconds: false,
+    showDate:    false,
+    color:       '#3b82f6',
+    label:       '',
+  })
+
+  try {
+    await page.goto(`/visu/${pageId}`)
+    await page.waitForLoadState('networkidle')
+
+    const timeEl = page.locator(`[data-widget-id="${widgetId}"] [data-testid="uhr-digital-time"]`)
+    await expect(timeEl).toBeVisible({ timeout: 5_000 })
+
+    // Format muss HH:MM sein (z.B. "14:35")
+    const text = await timeEl.textContent()
+    expect(text).toMatch(/^\d{2}:\d{2}$/)
+  } finally {
+    await apiDelete(`/api/v1/visu/nodes/${pageId}`)
+  }
+})
+
+// ─── Test 2: Digital-Modus – Sekunden ────────────────────────────────────────
+
+test('Uhr digital-Modus mit Sekunden: Format HH:MM:SS', async ({ page }) => {
+  const visuNode = await createVisuPage()
+  const pageId   = visuNode.id
+  const widgetId = randomUUID()
+
+  await buildUhrPage(pageId, widgetId, {
+    mode:        'digital',
+    showSeconds: true,
+    showDate:    false,
+    color:       '#10b981',
+    label:       'Testlabel',
+  })
+
+  try {
+    await page.goto(`/visu/${pageId}`)
+    await page.waitForLoadState('networkidle')
+
+    const timeEl = page.locator(`[data-widget-id="${widgetId}"] [data-testid="uhr-digital-time"]`)
+    await expect(timeEl).toBeVisible({ timeout: 5_000 })
+
+    const text = await timeEl.textContent()
+    expect(text).toMatch(/^\d{2}:\d{2}:\d{2}$/)
+  } finally {
+    await apiDelete(`/api/v1/visu/nodes/${pageId}`)
+  }
+})
+
+// ─── Test 3: Digital-Modus – Datum ───────────────────────────────────────────
+
+test('Uhr digital-Modus mit Datum: Datumselement ist sichtbar', async ({ page }) => {
+  const visuNode = await createVisuPage()
+  const pageId   = visuNode.id
+  const widgetId = randomUUID()
+
+  await buildUhrPage(pageId, widgetId, {
+    mode:        'digital',
+    showSeconds: false,
+    showDate:    true,
+    color:       '#3b82f6',
+    label:       '',
+  })
+
+  try {
+    await page.goto(`/visu/${pageId}`)
+    await page.waitForLoadState('networkidle')
+
+    const widgetEl = page.locator(`[data-widget-id="${widgetId}"]`)
+
+    await expect(widgetEl.locator('[data-testid="uhr-digital-time"]')).toBeVisible({ timeout: 5_000 })
+    await expect(widgetEl.locator('[data-testid="uhr-digital-date"]')).toBeVisible({ timeout: 3_000 })
+
+    // Datum muss das aktuelle Jahr enthalten
+    const dateText = await widgetEl.locator('[data-testid="uhr-digital-date"]').textContent()
+    const year     = new Date().getFullYear().toString()
+    expect(dateText).toContain(year)
+  } finally {
+    await apiDelete(`/api/v1/visu/nodes/${pageId}`)
+  }
+})
+
+// ─── Test 4: Analog-Modus ────────────────────────────────────────────────────
+
+test('Uhr analog-Modus: SVG-Uhr wird gerendert', async ({ page }) => {
+  const visuNode = await createVisuPage()
+  const pageId   = visuNode.id
+  const widgetId = randomUUID()
+
+  await buildUhrPage(pageId, widgetId, {
+    mode:        'analog',
+    showSeconds: true,
+    color:       '#f59e0b',
+    label:       'Analog-Test',
+  })
+
+  try {
+    await page.goto(`/visu/${pageId}`)
+    await page.waitForLoadState('networkidle')
+
+    const svgEl = page.locator(`[data-widget-id="${widgetId}"] [data-testid="uhr-analog"]`)
+    await expect(svgEl).toBeVisible({ timeout: 5_000 })
+
+    // SVG muss vorhanden sein
+    const tagName = await svgEl.evaluate(el => el.tagName.toLowerCase())
+    expect(tagName).toBe('svg')
+  } finally {
+    await apiDelete(`/api/v1/visu/nodes/${pageId}`)
+  }
+})
+
+// ─── Test 5: Wortuhr-Modus – Grunddarstellung ────────────────────────────────
+
+test('Uhr wortuhr-Modus: Buchstabenraster wird gerendert, 110 Zellen vorhanden', async ({ page }) => {
+  const visuNode = await createVisuPage()
+  const pageId   = visuNode.id
+  const widgetId = randomUUID()
+
+  await buildUhrPage(pageId, widgetId, {
+    mode:  'wortuhr',
+    color: '#3b82f6',
+    label: '',
+  })
+
+  try {
+    await page.goto(`/visu/${pageId}`)
+    await page.waitForLoadState('networkidle')
+
+    const wortuhrEl = page.locator(`[data-widget-id="${widgetId}"] [data-testid="uhr-wortuhr"]`)
+    await expect(wortuhrEl).toBeVisible({ timeout: 5_000 })
+
+    // 11 Spalten × 10 Zeilen = 110 Zellen
+    const zellen = wortuhrEl.locator('div > div')
+    await expect(zellen).toHaveCount(110, { timeout: 3_000 })
+  } finally {
+    await apiDelete(`/api/v1/visu/nodes/${pageId}`)
+  }
+})
+
+// ─── Test 6: Wortuhr-Modus – ES IST immer hervorgehoben ──────────────────────
+
+test('Uhr wortuhr-Modus: ES und IST sind immer in Akzentfarbe', async ({ page }) => {
+  const visuNode = await createVisuPage()
+  const pageId   = visuNode.id
+  const widgetId = randomUUID()
+  const color    = '#e11d48'
+
+  await buildUhrPage(pageId, widgetId, {
+    mode:  'wortuhr',
+    color,
+    label: '',
+  })
+
+  try {
+    await page.goto(`/visu/${pageId}`)
+    await page.waitForLoadState('networkidle')
+
+    const wortuhrEl = page.locator(`[data-widget-id="${widgetId}"] [data-testid="uhr-wortuhr"]`)
+    await expect(wortuhrEl).toBeVisible({ timeout: 5_000 })
+
+    // Prüfe, dass mindestens einige Zellen die Akzentfarbe haben
+    // (ES und IST sind immer aktiv → mindestens 5 hervorgehobene Buchstaben)
+    const hervorgehobeneZellen = await wortuhrEl.locator('div > div').evaluateAll(
+      (cells, accentColor) => cells.filter(
+        cell => (cell as HTMLElement).style.color === accentColor
+          || (cell as HTMLElement).style.color.includes(accentColor.slice(1)),
+      ).length,
+      color,
+    )
+
+    // ES (2) + IST (3) = mindestens 5 immer aktiv
+    expect(hervorgehobeneZellen).toBeGreaterThanOrEqual(5)
+  } finally {
+    await apiDelete(`/api/v1/visu/nodes/${pageId}`)
+  }
+})


### PR DESCRIPTION
Neues `Uhr`-Widget mit drei Darstellungsmodi:
- Digital: Grosses Zeitdisplay (HH:MM / HH:MM:SS) mit optionalem Datum
- Analog: SVG-Zifferblatt mit Stunden-, Minuten- und Sekundenzeiger
- Wortuhr: Deutsches 11×10 Buchstabenraster (QClock-Stil) mit korrekter FÜNF-VOR/NACH-HALB-Logik für alle 12 Stunden

Konfigurierbar: Modus, Akzentfarbe, Sekunden, Datum, Beschriftung. Kein Datenpunkt nötig (noDatapoint: true).
Playwright E2E-Tests für alle drei Modi in uhr.spec.ts.

Closes #167