### PR TITLE
Add experimental HomeKit Yahka migration API

### DIFF
--- a/docs/homekit-yahka-preview.md
+++ b/docs/homekit-yahka-preview.md
@@ -1,0 +1,105 @@
+# HomeKit/Yahka Mapping Preview
+
+OBS exposes an experimental read-only planning endpoint for the Yahka/Apple
+Home integration:
+
+```text
+POST /api/v1/homekit/preview
+```
+
+The endpoint generates a reviewable mapping from the existing VISU tree. It does
+not create ioBroker states, OBS bindings, Yahka accessories, or KNX fallback
+scripts.
+
+After review, OBS exposes a controlled apply endpoint:
+
+```text
+POST /api/v1/homekit/apply
+```
+
+The default is `dry_run: true`, so the first call returns the import plan without
+changing OBS or ioBroker. Treat this API as a migration helper: review the
+preview output before running a non-dry-run apply.
+
+## Request
+
+```json
+{
+  "project": "My Home",
+  "root_node_id": "00000000-0000-0000-0000-000000000000",
+  "source_visu_name": "Home",
+  "leading_iobroker_name": "ioBroker",
+  "leading_iobroker_host": "localhost",
+  "leading_iobroker_port": 8082,
+  "room_strategy": "floor_prefix",
+  "accessory_limit_per_bridge": 150,
+  "namespace_prefix": "0_userdata.0.obs.home"
+}
+```
+
+`root_node_id` is optional. If omitted, OBS looks for a VISU root named
+`source_visu_name`.
+
+## Output
+
+The response contains:
+
+- normalized ioBroker Home-State IDs
+- Apple Home room and accessory names
+- per-state `binding_direction`
+- OBS binding direction needed for the current adapter model
+- status-DP metadata for lights and outlets
+- HomeKit bridge limit summary
+- system heartbeat states
+- backup and restore checklist items
+
+The conceptual binding directions are:
+
+```text
+BOTH      writable HomeKit states
+FROM_OBS  read-only status states
+```
+
+For OBS adapter bindings, `FROM_OBS` maps to the existing adapter direction
+`DEST`, because OBS writes the value to ioBroker/Yahka and does not subscribe to
+ioBroker changes for that state.
+
+## Current Scope
+
+The preview maps these VISU widgets:
+
+- `Licht` -> `Lightbulb`
+- `Toggle` -> `Switch` or `Outlet`
+- `Fenster` -> `ContactSensor`
+- `Rolladen` -> `WindowCovering`
+- `RTR` -> `Thermostat`
+- `ValueDisplay` temperature/humidity -> sensor
+
+Unsupported widgets are returned as `Unsupported` with warnings so the mapping
+can be reviewed before any productive import is implemented.
+
+## Apply Request
+
+```json
+{
+  "project": "My Home",
+  "root_node_id": "00000000-0000-0000-0000-000000000000",
+  "iobroker_instance_id": "11111111-1111-1111-1111-111111111111",
+  "dry_run": true,
+  "create_iobroker_states": false,
+  "room_keys": ["kitchen"],
+  "include_unsupported": false
+}
+```
+
+When `dry_run` is `false`, OBS creates:
+
+- one OBS datapoint per normalized Home-State
+- one ioBroker binding per Home-State
+
+The import is idempotent by ioBroker `state_id`: existing bindings for the same
+ioBroker instance are skipped.
+
+When `create_iobroker_states` is `true`, the running ioBroker adapter also calls
+`setObject` for each state. This requires the selected ioBroker adapter instance
+to be connected. Keep this disabled for the first review run.

--- a/docs/homekit-yahka-project-overview.md
+++ b/docs/homekit-yahka-project-overview.md
@@ -1,0 +1,210 @@
+# HomeKit/Yahka Integration for OBS
+
+## Why this project exists
+
+Many installations already use OBS as the place where rooms, widgets,
+datapoints, KNX bindings, and automation logic come together. At the same time,
+Apple Home is often reached through ioBroker and Yahka because they already
+provide a practical HomeKit bridge.
+
+Without an OBS-aware integration workflow, Apple Home onboarding tends to be
+manual and error-prone:
+
+- HomeKit state IDs are created by hand
+- existing OBS and KNX datapoints are duplicated instead of reused
+- write and status paths drift apart
+- naming, room structure, and behavior become inconsistent across systems
+- fallback and restore behavior are hard to reason about later
+
+This project adds a structured migration/helper layer to OBS so existing VISU
+and adapter models can be translated into stable HomeKit-facing ioBroker states
+and bindings in a predictable way.
+
+## Core idea
+
+The core idea is simple:
+
+`OBS stays the source of structure. ioBroker/Yahka stays the HomeKit bridge.`
+
+OBS already knows the installation's rooms, widgets, datapoints, and protocol
+bindings. That means OBS can generate a reviewable HomeKit plan from the VISU
+tree instead of asking the user to remodel the same installation a second time
+inside Yahka.
+
+The integration therefore does not try to replace Yahka. It helps prepare and
+maintain the data model that Yahka needs:
+
+- stable ioBroker state IDs
+- predictable room and accessory naming
+- explicit read/write direction per state
+- reuse of existing KNX/ETS datapoints where possible
+- clear detection of unsupported or risky cases before productive changes happen
+
+## What OBS adds
+
+The new OBS-side feature set is an experimental migration helper with two main
+steps.
+
+### 1. Preview
+
+OBS can analyze the existing VISU tree and generate a reviewable HomeKit/Yahka
+mapping preview.
+
+The preview shows:
+
+- rooms and accessories derived from the VISU hierarchy
+- normalized ioBroker state IDs
+- the intended HomeKit service type
+- binding direction per state
+- KNX status/write datapoint metadata where available
+- warnings for unsupported widgets or risky mappings
+- estimated accessory count and bridge-limit pressure
+
+The preview is intentionally read-only.
+
+### 2. Controlled apply
+
+After review, OBS can execute a controlled apply step.
+
+This apply logic can:
+
+- create missing OBS datapoints when truly needed
+- reuse existing KNX/ETS datapoints instead of creating parallel HomeKit objects
+- create ioBroker bindings for the generated HomeKit-facing state IDs
+- optionally create the corresponding ioBroker states through the native
+  ioBroker adapter
+
+The apply flow is dry-run first by default and designed to be idempotent where
+possible.
+
+## Why this is useful beyond one installation
+
+Although the original driver was a concrete migration project, the value is not
+site-specific. The useful general part for OBS is:
+
+- using the VISU model as a source for external integration planning
+- generating stable, reviewable state namespaces from widgets and rooms
+- attaching external integration bindings to existing datapoints instead of
+  duplicating the object model
+- making risky integration work previewable before writes occur
+- codifying read/write semantics for external bridges such as HomeKit
+
+That pattern can be useful anywhere OBS acts as the system-of-record for the
+building model and another system acts as the end-user presentation bridge.
+
+## Current scope
+
+The current preview/apply flow targets these widget families:
+
+- `Licht` -> `Lightbulb`
+- `Toggle` -> `Switch` or `Outlet`
+- `Fenster` -> `ContactSensor`
+- `Rolladen` -> `WindowCovering`
+- `RTR` -> `Thermostat`
+- `ValueDisplay` -> temperature or humidity sensor when detectable
+
+Unsupported widgets are not silently ignored. They are surfaced as review items
+so the user can decide what should happen before a productive rollout.
+
+## Design principles
+
+Several design principles matter more than any single endpoint:
+
+- Reuse before create:
+  Existing KNX/ETS-backed OBS datapoints should remain the leading objects
+  whenever they already represent the target function.
+
+- Preview before write:
+  The user should be able to inspect the exact mapping and apply plan before any
+  productive change is made.
+
+- Explicit direction:
+  Writable HomeKit states and read-only status states must not be treated the
+  same. The integration needs a clear semantic distinction between
+  bidirectional states and status-only states.
+
+- Stable naming:
+  HomeKit-facing ioBroker state IDs must stay predictable and durable over time.
+
+- Upstream-safe defaults:
+  Core code and docs should stay neutral and not depend on one installation's
+  hostnames, IPs, bridge identities, or room names.
+
+## Relationship to the native ioBroker adapter
+
+This project builds on top of the native ioBroker adapter work in OBS.
+
+That adapter already provides the technical foundation needed for a generic
+HomeKit/Yahka workflow:
+
+- connect to one or more ioBroker instances
+- browse ioBroker states
+- subscribe to live state changes
+- write back to ioBroker states
+- create ioBroker states programmatically
+- recover from reconnect/resubscribe scenarios more reliably
+
+The HomeKit/Yahka helper is therefore best understood as an adapter-oriented
+workflow, not as a separate HomeKit runtime inside OBS.
+
+## Intended GUI direction
+
+The most natural GUI placement is inside the adapter section, scoped to a
+selected ioBroker instance:
+
+`Adapter -> ioBroker -> HomeKit/Yahka`
+
+That keeps the workflow close to the adapter instance that will receive the
+generated bindings and optional state creation. It also avoids turning the OBS
+GUI into a full Yahka management tool.
+
+The most useful GUI stages are:
+
+- Preview
+- Plan / dry-run
+- Apply
+
+This is enough to make the workflow understandable and safe without duplicating
+all Yahka-specific administration in OBS.
+
+## What this project is not
+
+This project does not aim to:
+
+- replace Yahka as the HomeKit bridge
+- manage HomeKit pairing/HAP identities directly in OBS
+- become a full Apple Home configuration editor
+- hide fallback, restore, or bridge-limit concerns behind magic defaults
+
+Those concerns remain important, but they should stay explicit.
+
+## Practical outcome
+
+In practical terms, this project gives OBS a new role:
+
+OBS becomes the place where an existing installation can be translated into a
+structured, reviewable, and partially automatable HomeKit/Yahka rollout instead
+of forcing users to rebuild that structure manually in parallel systems.
+
+That is valuable for:
+
+- first-time Apple Home onboarding
+- controlled pilot migrations room by room
+- avoiding datapoint duplication
+- documenting integration intent
+- future maintenance, restore, and troubleshooting work
+
+## Summary
+
+The kernel of the concept is not "add HomeKit to OBS directly."
+
+The kernel is:
+
+- use OBS as the source of truth for structure
+- use ioBroker/Yahka as the HomeKit bridge
+- let OBS generate and apply a safe, reviewable integration plan
+- preserve the existing datapoint model instead of fragmenting it
+
+That makes the feature useful not only for one local migration, but as a
+general integration pattern for OBS installations that want a structured path
+into Apple Home.

--- a/docs/homekit_yahka_obs_integration_de.md
+++ b/docs/homekit_yahka_obs_integration_de.md
@@ -1,0 +1,168 @@
+# HomeKit/Yahka-Integration für OBS
+
+## Warum dieses Projekt existiert
+
+Viele Installationen nutzen OBS bereits als zentrale Plattform, in der Räume, Widgets,
+Datenpunkte, KNX-Bindings und Automationslogik zusammenlaufen. Gleichzeitig wird
+Apple Home häufig über ioBroker und Yahka angebunden, da diese bereits eine
+praktische HomeKit-Bridge bereitstellen.
+
+Ohne einen OBS-orientierten Integrations-Workflow ist das Onboarding in Apple Home
+oft manuell und fehleranfällig:
+
+- HomeKit-State-IDs werden von Hand erstellt  
+- bestehende OBS- und KNX-Datenpunkte werden dupliziert statt wiederverwendet  
+- Schreib- und Statuspfade laufen auseinander  
+- Benennung, Raumstruktur und Verhalten werden inkonsistent  
+- Fallback- und Restore-Verhalten sind später schwer nachvollziehbar  
+
+Dieses Projekt ergänzt OBS um eine strukturierte Migrations- und Helper-Schicht,
+sodass bestehende VISU- und Adaptermodelle reproduzierbar in stabile,
+HomeKit-seitige ioBroker-States und Bindings überführt werden können.
+
+## Kernidee
+
+Die Kernidee ist einfach:
+
+`OBS bleibt die Quelle der Struktur. ioBroker/Yahka bleibt die HomeKit-Bridge.`
+
+OBS kennt bereits Räume, Widgets, Datenpunkte und Protokollbindungen der Installation.
+Damit kann OBS aus dem VISU-Baum einen überprüfbaren HomeKit-Plan generieren,
+anstatt den Nutzer zu zwingen, dieselbe Struktur ein zweites Mal in Yahka nachzubauen.
+
+Die Integration ersetzt Yahka nicht, sondern bereitet das Datenmodell vor, das Yahka benötigt:
+
+- stabile ioBroker-State-IDs  
+- konsistente Raum- und Accessory-Benennung  
+- explizite Lese-/Schreibrichtung pro State  
+- Wiederverwendung bestehender KNX/ETS-Datenpunkte  
+- klare Erkennung nicht unterstützter oder riskanter Fälle vor produktiven Änderungen  
+
+## Was OBS ergänzt
+
+Die neue OBS-Funktionalität ist ein experimenteller Migrations-Helper mit zwei Hauptschritten.
+
+### 1. Vorschau (Preview)
+
+OBS analysiert den bestehenden VISU-Baum und erzeugt eine überprüfbare
+HomeKit/Yahka-Mapping-Vorschau.
+
+Die Vorschau zeigt:
+
+- Räume und Accessories aus der VISU-Hierarchie  
+- normalisierte ioBroker-State-IDs  
+- den vorgesehenen HomeKit-Service-Typ  
+- Bindungsrichtung pro State  
+- KNX-Status-/Schreib-Datenpunkte (sofern vorhanden)  
+- Warnungen für nicht unterstützte Widgets oder riskante Mappings  
+- geschätzte Anzahl an Accessories und Bridge-Limit-Auslastung  
+
+Die Vorschau ist bewusst read-only.
+
+### 2. Kontrollierte Anwendung (Apply)
+
+Nach der Prüfung kann OBS einen kontrollierten Apply-Schritt ausführen.
+
+Dabei kann:
+
+- fehlende OBS-Datenpunkte nur bei Bedarf angelegt werden  
+- bestehende KNX/ETS-Datenpunkte wiederverwendet werden  
+- ioBroker-Bindings für die generierten State-IDs erstellt werden  
+- optional die entsprechenden ioBroker-States erzeugt werden  
+
+Der Apply-Prozess erfolgt standardmäßig zunächst als Dry-Run und ist
+möglichst idempotent ausgelegt.
+
+## Nutzen über eine einzelne Installation hinaus
+
+Der Mehrwert ist nicht installationsspezifisch. Allgemein relevant für OBS ist:
+
+- Nutzung des VISU-Modells für externe Integrationsplanung  
+- Generierung stabiler, überprüfbarer State-Namensräume  
+- Anbindung externer Systeme an bestehende Datenpunkte statt Duplikation  
+- Vorschau risikobehafteter Integrationen vor produktiven Änderungen  
+- klare Definition von Lese-/Schreibsemantik für externe Bridges  
+
+Dieses Muster ist überall sinnvoll, wo OBS als System-of-Record dient und ein
+anderes System die Benutzeroberfläche bildet.
+
+## Aktueller Umfang
+
+Aktuell werden folgende Widget-Familien unterstützt:
+
+- `Licht` -> `Lightbulb`  
+- `Toggle` -> `Switch` oder `Outlet`  
+- `Fenster` -> `ContactSensor`  
+- `Rolladen` -> `WindowCovering`  
+- `RTR` -> `Thermostat`  
+- `ValueDisplay` -> Temperatur- oder Feuchtigkeitssensor  
+
+Nicht unterstützte Widgets werden nicht ignoriert, sondern explizit angezeigt.
+
+## Designprinzipien
+
+- Wiederverwenden statt neu erstellen  
+- Vorschau vor Schreiben  
+- Explizite Richtung (read/write)  
+- Stabile Benennung  
+- Neutrale, installationsunabhängige Defaults  
+
+## Beziehung zum nativen ioBroker-Adapter
+
+Das Projekt baut auf dem bestehenden ioBroker-Adapter in OBS auf.
+
+Dieser bietet:
+
+- Verbindung zu ioBroker-Instanzen  
+- Zugriff auf States  
+- Live-Subscriptions  
+- Schreibzugriff  
+- programmgesteuerte State-Erstellung  
+- robuste Reconnect-Mechanismen  
+
+Der HomeKit/Yahka-Helper ist somit ein Workflow auf Adapterbasis,
+kein eigener HomeKit-Stack.
+
+## GUI-Ausrichtung
+
+Platzierung:
+
+`Adapter -> ioBroker -> HomeKit/Yahka`
+
+Workflow-Stufen:
+
+- Preview  
+- Plan / Dry-Run  
+- Apply  
+
+## Was dieses Projekt nicht ist
+
+- kein Ersatz für Yahka  
+- kein HomeKit-Pairing-Manager  
+- kein Apple-Home-Editor  
+- keine „magischen Defaults“ für komplexe Themen  
+
+## Praktischer Nutzen
+
+OBS wird zur zentralen Instanz für:
+
+- strukturiertes HomeKit-Onboarding  
+- kontrollierte Migrationen  
+- Vermeidung von Datenpunkt-Duplikaten  
+- Dokumentation der Integrationslogik  
+- Wartung und Troubleshooting  
+
+## Zusammenfassung
+
+Der Kern ist nicht:
+
+„HomeKit direkt in OBS integrieren“
+
+Der Kern ist:
+
+- OBS als strukturelle Quelle nutzen  
+- ioBroker/Yahka als Bridge verwenden  
+- Integration planbar und überprüfbar machen  
+- bestehende Datenmodelle erhalten  
+
+Damit entsteht ein allgemeines Integrationsmuster für OBS-basierte Systeme.

--- a/gui/src/api/client.js
+++ b/gui/src/api/client.js
@@ -127,6 +127,11 @@ export const knxprojApi = {
   clearGA: ()         => api.delete('/knxproj/group-addresses'),
 }
 
+export const homekitApi = {
+  preview: (data) => api.post('/homekit/preview', data),
+  apply:   (data) => api.post('/homekit/apply', data),
+}
+
 // ── System ────────────────────────────────────────────────────────────────
 export const systemApi = {
   health:    () => axios.get('/api/v1/system/health'),  // no auth

--- a/obs/api/router.py
+++ b/obs/api/router.py
@@ -3,6 +3,7 @@ FastAPI Router Aggregator — Phase 4/5
 
 Mounts all v1 sub-routers under /api/v1.
 """
+
 from __future__ import annotations
 
 from fastapi import APIRouter
@@ -23,22 +24,24 @@ from obs.api.v1.visu import router as visu_router
 from obs.api.v1.icons import router as icons_router
 from obs.api.v1.camera import router as camera_router
 from obs.api.v1.weather import router as weather_router
+from obs.api.v1.homekit import router as homekit_router
 
 router = APIRouter()
 
 router.include_router(auth_router)
-router.include_router(dp_router,       prefix="/datapoints")
+router.include_router(dp_router, prefix="/datapoints")
 router.include_router(bindings_router, prefix="/datapoints")
-router.include_router(search_router,   prefix="/search")
+router.include_router(search_router, prefix="/search")
 router.include_router(adapters_router, prefix="/adapters")
-router.include_router(system_router,   prefix="/system")
+router.include_router(system_router, prefix="/system")
 router.include_router(ws_router)
-router.include_router(rb_router,       prefix="/ringbuffer")
-router.include_router(history_router,  prefix="/history")
-router.include_router(config_router,   prefix="/config")
-router.include_router(knxproj_router,  prefix="/knxproj")
-router.include_router(logic_router,    prefix="/logic")
-router.include_router(visu_router,     prefix="/visu")
-router.include_router(icons_router,    prefix="/icons")
-router.include_router(camera_router,   prefix="/camera")
-router.include_router(weather_router,  prefix="/weather")
+router.include_router(rb_router, prefix="/ringbuffer")
+router.include_router(history_router, prefix="/history")
+router.include_router(config_router, prefix="/config")
+router.include_router(knxproj_router, prefix="/knxproj")
+router.include_router(logic_router, prefix="/logic")
+router.include_router(visu_router, prefix="/visu")
+router.include_router(icons_router, prefix="/icons")
+router.include_router(camera_router, prefix="/camera")
+router.include_router(weather_router, prefix="/weather")
+router.include_router(homekit_router, prefix="/homekit")

--- a/obs/api/v1/adapters.py
+++ b/obs/api/v1/adapters.py
@@ -542,7 +542,7 @@ async def iobroker_browse_states(
         raise HTTPException(status.HTTP_400_BAD_REQUEST, "Nur für IOBROKER-Instanzen verfügbar")
 
     instance = adapter_registry.get_instance_by_id(str(instance_id))
-    if instance is None or not getattr(instance, "connected", False):
+    if instance is None:
         raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, "ioBroker-Instanz ist nicht verbunden")
     if not hasattr(instance, "browse_states"):
         raise HTTPException(status.HTTP_501_NOT_IMPLEMENTED, "ioBroker-State-Browser nicht verfügbar")
@@ -608,7 +608,7 @@ async def _iobroker_candidates(
     db: Database,
 ) -> list[IoBrokerImportItem]:
     instance = adapter_registry.get_instance_by_id(instance_id)
-    if instance is None or not getattr(instance, "connected", False):
+    if instance is None:
         raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, "ioBroker-Instanz ist nicht verbunden")
     states = await instance.browse_states(body.prefix, min(max(body.limit, 1), 500))
     selected = set(body.states)

--- a/obs/api/v1/homekit.py
+++ b/obs/api/v1/homekit.py
@@ -1,0 +1,54 @@
+"""Experimental HomeKit/Yahka migration API."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from obs.api.auth import get_current_user
+from obs.core.registry import get_registry
+from obs.db.database import Database, get_db
+from obs.homekit.yahka import (
+    HomeKitApplyRequest,
+    HomeKitApplyResult,
+    HomeKitPreview,
+    HomeKitPreviewOptions,
+    apply_mapping,
+    build_preview,
+)
+
+router = APIRouter(tags=["homekit"])
+
+
+@router.post("/preview", response_model=HomeKitPreview)
+async def preview_homekit_mapping(
+    body: HomeKitPreviewOptions,
+    _user: str = Depends(get_current_user),
+    db: Database = Depends(lambda: get_db()),
+) -> HomeKitPreview:
+    """Generate a reviewable Yahka/HomeKit mapping from the VISU tree.
+
+    This experimental endpoint is intentionally read-only. It does not create
+    ioBroker states, OBS bindings, or Yahka configuration.
+    """
+    try:
+        return await build_preview(db, body)
+    except ValueError as exc:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, str(exc)) from exc
+
+
+@router.post("/apply", response_model=HomeKitApplyResult)
+async def apply_homekit_mapping(
+    body: HomeKitApplyRequest,
+    _user: str = Depends(get_current_user),
+    db: Database = Depends(lambda: get_db()),
+) -> HomeKitApplyResult:
+    """Create OBS datapoints and ioBroker bindings from the mapping preview.
+
+    This is an experimental migration helper. The default is ``dry_run=true``.
+    In dry-run mode the endpoint returns the exact create/skip plan without
+    writing to OBS or ioBroker.
+    """
+    try:
+        return await apply_mapping(db, get_registry(), body)
+    except ValueError as exc:
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_CONTENT, str(exc)) from exc

--- a/obs/homekit/__init__.py
+++ b/obs/homekit/__init__.py
@@ -1,0 +1,1 @@
+"""HomeKit/Yahka planning helpers."""

--- a/obs/homekit/yahka.py
+++ b/obs/homekit/yahka.py
@@ -1,0 +1,1245 @@
+"""Generate Yahka/Apple Home mapping previews from the OBS VISU model.
+
+The generator intentionally starts with a reviewable mapping before it writes
+anything. It provides stable state names, explicit binding directions, status-GA
+metadata, and warnings where manual review is still needed.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import unicodedata
+import uuid
+from collections import defaultdict
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from obs.db.database import Database
+
+
+BindingDirection = Literal["BOTH", "FROM_OBS"]
+ObsBindingDirection = Literal["BOTH", "DEST"]
+
+
+class HomeKitStateSpec(BaseModel):
+    id: str
+    data_type: str
+    binding_direction: BindingDirection
+    obs_binding_direction: ObsBindingDirection
+    persistent: bool = True
+    initial_value: Any = None
+    notes: list[str] = Field(default_factory=list)
+
+
+class HomeKitObsSpec(BaseModel):
+    switch_dp_id: str | None = None
+    status_dp_id: str | None = None
+    status_confirms_write: bool = False
+    optimistic_update: bool = False
+    binding_direction: BindingDirection | None = None
+    knx_write_ga: str | None = None
+    knx_status_ga: str | None = None
+    extra: dict[str, Any] = Field(default_factory=dict)
+
+
+class HomeKitFallbackSpec(BaseModel):
+    enabled: bool = False
+    knx_write_ga: str | None = None
+    knx_status_ga: str | None = None
+    notes: list[str] = Field(default_factory=list)
+
+
+class HomeKitAccessorySpec(BaseModel):
+    name_key: str
+    apple_home_name: str
+    type: str
+    widget_id: str | None = None
+    widget_type: str | None = None
+    states: dict[str, HomeKitStateSpec] = Field(default_factory=dict)
+    obs: HomeKitObsSpec = Field(default_factory=HomeKitObsSpec)
+    fallback: HomeKitFallbackSpec = Field(default_factory=HomeKitFallbackSpec)
+    warnings: list[str] = Field(default_factory=list)
+
+
+class HomeKitRoomSpec(BaseModel):
+    floor: str
+    room_key: str
+    room_display_name: str
+    apple_home_room: str
+    accessories: list[HomeKitAccessorySpec] = Field(default_factory=list)
+
+
+class HomeKitPreviewSummary(BaseModel):
+    rooms: int = 0
+    accessories: int = 0
+    lightbulb: int = 0
+    outlet: int = 0
+    switch: int = 0
+    contact_sensor: int = 0
+    window_covering: int = 0
+    thermostat: int = 0
+    temperature_sensor: int = 0
+    humidity_sensor: int = 0
+    unsupported: int = 0
+    needs_manual_review: int = 0
+    exceeds_single_bridge_limit: bool = False
+    recommended_bridges: int = 1
+
+
+class HomeKitSystemStateSpec(BaseModel):
+    id: str
+    data_type: str
+    writer: str
+    source: str | None = None
+    notes: list[str] = Field(default_factory=list)
+
+
+class HomeKitPreview(BaseModel):
+    project: str
+    source_visu: str
+    leading_iobroker: dict[str, Any]
+    room_strategy: str
+    accessory_limit_per_bridge: int = 150
+    rooms: list[HomeKitRoomSpec] = Field(default_factory=list)
+    summary: HomeKitPreviewSummary
+    warnings: list[str] = Field(default_factory=list)
+    system_states: list[HomeKitSystemStateSpec] = Field(default_factory=list)
+    backup_items: list[str] = Field(default_factory=list)
+    restore_tests: list[str] = Field(default_factory=list)
+
+
+class HomeKitPreviewOptions(BaseModel):
+    project: str = "OBS Home"
+    root_node_id: str | None = None
+    source_visu_name: str = "Home"
+    leading_iobroker_name: str = "ioBroker"
+    leading_iobroker_host: str = "localhost"
+    leading_iobroker_port: int = 8082
+    room_strategy: Literal["floor_prefix", "homekit_zones"] = "floor_prefix"
+    accessory_limit_per_bridge: int = Field(default=150, ge=1)
+    namespace_prefix: str = "0_userdata.0.obs.home"
+
+
+class HomeKitApplyRequest(HomeKitPreviewOptions):
+    iobroker_instance_id: uuid.UUID
+    dry_run: bool = True
+    create_iobroker_states: bool = False
+    room_keys: list[str] = Field(default_factory=list)
+    include_unsupported: bool = False
+
+
+class HomeKitApplyItem(BaseModel):
+    state_id: str
+    room: str
+    accessory: str
+    accessory_type: str
+    state_key: str
+    data_type: str
+    binding_direction: BindingDirection
+    obs_binding_direction: ObsBindingDirection
+    action: Literal[
+        "create", "reuse_existing", "skip_existing", "skip_unsupported", "error"
+    ]
+    datapoint_id: str | None = None
+    binding_id: str | None = None
+    iobroker_state_created: bool = False
+    message: str | None = None
+
+
+class HomeKitApplyResult(BaseModel):
+    dry_run: bool
+    created_datapoints: int = 0
+    created_bindings: int = 0
+    created_iobroker_states: int = 0
+    skipped_existing: int = 0
+    skipped_unsupported: int = 0
+    errors: list[str] = Field(default_factory=list)
+    items: list[HomeKitApplyItem] = Field(default_factory=list)
+    preview_summary: HomeKitPreviewSummary
+    apply_summary: HomeKitPreviewSummary = Field(default_factory=HomeKitPreviewSummary)
+
+
+_UMLAUTS = {
+    "ä": "ae",
+    "ö": "oe",
+    "ü": "ue",
+    "ß": "ss",
+    "Ä": "ae",
+    "Ö": "oe",
+    "Ü": "ue",
+}
+
+
+def slugify(value: str, fallback: str = "item") -> str:
+    value = "".join(_UMLAUTS.get(ch, ch) for ch in value.strip())
+    value = unicodedata.normalize("NFKD", value).encode("ascii", "ignore").decode()
+    value = re.sub(r"[^a-zA-Z0-9]+", "_", value).strip("_").lower()
+    value = re.sub(r"_+", "_", value)
+    return value or fallback
+
+
+def _state_id(
+    opts: HomeKitPreviewOptions, floor: str, room: str, accessory: str, prop: str
+) -> str:
+    return ".".join(
+        [
+            opts.namespace_prefix.rstrip("."),
+            slugify(floor),
+            slugify(room),
+            slugify(accessory),
+            slugify(prop),
+        ]
+    )
+
+
+def _state(
+    opts: HomeKitPreviewOptions,
+    floor: str,
+    room: str,
+    accessory: str,
+    prop: str,
+    data_type: str,
+    direction: BindingDirection,
+    initial_value: Any = None,
+    notes: list[str] | None = None,
+) -> HomeKitStateSpec:
+    return HomeKitStateSpec(
+        id=_state_id(opts, floor, room, accessory, prop),
+        data_type=data_type,
+        binding_direction=direction,
+        obs_binding_direction="BOTH" if direction == "BOTH" else "DEST",
+        initial_value=initial_value,
+        notes=notes or [],
+    )
+
+
+def _display_label(widget: dict[str, Any], default: str) -> str:
+    config = widget.get("config") or {}
+    for key in ("label", "name", "title"):
+        value = config.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    value = widget.get("name")
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return default
+
+
+def _dp_id(widget: dict[str, Any], *keys: str) -> str | None:
+    config = widget.get("config") or {}
+    for key in keys:
+        value = config.get(key)
+        if value:
+            return str(value)
+    value = widget.get("datapoint_id")
+    if value:
+        return str(value)
+    return None
+
+
+def _status_dp_id(widget: dict[str, Any], *keys: str) -> str | None:
+    config = widget.get("config") or {}
+    for key in keys:
+        value = config.get(key)
+        if value:
+            return str(value)
+    value = widget.get("status_datapoint_id")
+    if value:
+        return str(value)
+    return None
+
+
+def _bool_opt(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    return bool(value)
+
+
+async def _load_dp_index(db: Database) -> dict[str, dict[str, Any]]:
+    rows = await db.fetchall("SELECT * FROM datapoints")
+    out: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        out[row["id"]] = {
+            "id": row["id"],
+            "name": row["name"],
+            "data_type": row["data_type"],
+            "unit": row["unit"],
+            "tags": json.loads(row["tags"] or "[]"),
+        }
+    return out
+
+
+async def _load_knx_index(db: Database) -> dict[str, dict[str, Any]]:
+    rows = await db.fetchall(
+        "SELECT * FROM adapter_bindings WHERE adapter_type='KNX' AND enabled=1"
+    )
+    out: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        try:
+            cfg = json.loads(row["config"] or "{}")
+        except Exception:
+            cfg = {}
+        out.setdefault(row["datapoint_id"], cfg)
+    return out
+
+
+async def _load_visu_rows(db: Database) -> list[dict[str, Any]]:
+    rows = await db.fetchall("SELECT * FROM visu_nodes ORDER BY node_order ASC")
+    return [dict(row) for row in rows]
+
+
+def _find_root(
+    rows: list[dict[str, Any]], opts: HomeKitPreviewOptions
+) -> dict[str, Any] | None:
+    if opts.root_node_id:
+        return next((r for r in rows if r["id"] == opts.root_node_id), None)
+    return next((r for r in rows if r["name"] == opts.source_visu_name), None)
+
+
+def _descendants(rows: list[dict[str, Any]], root_id: str) -> list[dict[str, Any]]:
+    children: dict[str | None, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        children[row["parent_id"]].append(row)
+
+    result: list[dict[str, Any]] = []
+    stack = list(children.get(root_id, []))
+    while stack:
+        row = stack.pop(0)
+        result.append(row)
+        stack[0:0] = children.get(row["id"], [])
+    return result
+
+
+def _path_for(
+    node: dict[str, Any], rows_by_id: dict[str, dict[str, Any]], root_id: str
+) -> list[dict[str, Any]]:
+    path: list[dict[str, Any]] = [node]
+    parent_id = node.get("parent_id")
+    while parent_id and parent_id != root_id and parent_id in rows_by_id:
+        parent = rows_by_id[parent_id]
+        path.insert(0, parent)
+        parent_id = parent.get("parent_id")
+    return path
+
+
+def _page_widgets(row: dict[str, Any]) -> list[dict[str, Any]]:
+    try:
+        pc = json.loads(row.get("page_config") or "{}")
+    except Exception:
+        return []
+    widgets = pc.get("widgets", [])
+    return widgets if isinstance(widgets, list) else []
+
+
+def _knx_ga(
+    knx_index: dict[str, dict[str, Any]], dp_id: str | None
+) -> tuple[str | None, str | None]:
+    if not dp_id:
+        return None, None
+    cfg = knx_index.get(dp_id) or {}
+    return cfg.get("group_address"), cfg.get("state_group_address")
+
+
+def _set_obs_from_dps(
+    acc: HomeKitAccessorySpec,
+    switch_dp: str | None,
+    status_dp: str | None,
+    knx_index: dict[str, dict[str, Any]],
+) -> None:
+    write_ga, write_status_ga = _knx_ga(knx_index, switch_dp)
+    status_ga, status_state_ga = _knx_ga(knx_index, status_dp)
+    acc.obs.switch_dp_id = switch_dp
+    acc.obs.status_dp_id = status_dp
+    acc.obs.status_confirms_write = bool(status_dp)
+    acc.obs.optimistic_update = not bool(status_dp)
+    acc.obs.knx_write_ga = write_ga
+    acc.obs.knx_status_ga = status_ga or write_status_ga or status_state_ga
+    acc.obs.binding_direction = "BOTH"
+    acc.fallback.knx_write_ga = acc.obs.knx_write_ga
+    acc.fallback.knx_status_ga = acc.obs.knx_status_ga
+    acc.fallback.enabled = bool(acc.obs.knx_write_ga and acc.obs.knx_status_ga)
+    if not status_dp:
+        acc.warnings.append(
+            "Keine Status-DP/Status-GA erkannt: optimistic_update waere erforderlich."
+        )
+
+
+def _light_accessory(
+    widget: dict[str, Any],
+    floor: str,
+    room: str,
+    opts: HomeKitPreviewOptions,
+    knx_index: dict[str, dict[str, Any]],
+) -> HomeKitAccessorySpec:
+    label = _display_label(widget, "Licht")
+    cfg = widget.get("config") or {}
+    acc = HomeKitAccessorySpec(
+        name_key=slugify(label),
+        apple_home_name=label,
+        type="Lightbulb",
+        widget_id=widget.get("id"),
+        widget_type=widget.get("type"),
+    )
+    switch_dp = _dp_id(widget, "dp_switch")
+    status_dp = _status_dp_id(widget, "dp_switch_status")
+    _set_obs_from_dps(acc, switch_dp, status_dp, knx_index)
+    acc.states["on"] = _state(opts, floor, room, label, "on", "boolean", "BOTH")
+    if cfg.get("dp_dim"):
+        acc.states["brightness"] = _state(
+            opts, floor, room, label, "brightness", "number", "BOTH"
+        )
+        acc.obs.extra["brightness_dp_id"] = cfg.get("dp_dim")
+        acc.obs.extra["brightness_status_dp_id"] = cfg.get("dp_dim_status") or None
+    return acc
+
+
+def _toggle_accessory(
+    widget: dict[str, Any],
+    floor: str,
+    room: str,
+    opts: HomeKitPreviewOptions,
+    knx_index: dict[str, dict[str, Any]],
+    dp_index: dict[str, dict[str, Any]],
+) -> HomeKitAccessorySpec:
+    label = _display_label(widget, "Schalter")
+    dp = _dp_id(widget)
+    dp_name = (dp_index.get(dp or "", {}).get("name") or "").lower()
+    haystack = f"{label} {dp_name}".lower()
+    acc_type = (
+        "Outlet"
+        if any(part in haystack for part in ("steck", "socket", "outlet", "plug"))
+        else "Switch"
+    )
+    acc = HomeKitAccessorySpec(
+        name_key=slugify(label),
+        apple_home_name=label,
+        type=acc_type,
+        widget_id=widget.get("id"),
+        widget_type=widget.get("type"),
+    )
+    status_dp = _status_dp_id(widget)
+    _set_obs_from_dps(acc, dp, status_dp, knx_index)
+    acc.states["on"] = _state(opts, floor, room, label, "on", "boolean", "BOTH")
+    if acc_type == "Outlet":
+        acc.states["outlet_in_use"] = _state(
+            opts,
+            floor,
+            room,
+            label,
+            "outlet_in_use",
+            "boolean",
+            "FROM_OBS",
+            initial_value=True,
+            notes=["Statisch true, wenn kein echter Verbrauchssensor vorhanden ist."],
+        )
+    return acc
+
+
+def _contact_accessories(
+    widget: dict[str, Any],
+    floor: str,
+    room: str,
+    opts: HomeKitPreviewOptions,
+) -> list[HomeKitAccessorySpec]:
+    label = _display_label(widget, "Fenster")
+    cfg = widget.get("config") or {}
+    specs = [
+        ("contact", "dp_contact", "invert_contact", label),
+        ("tilt", "dp_tilt", "invert_tilt", f"{label} Kipp"),
+        ("contact_left", "dp_contact_left", "invert_contact_left", f"{label} links"),
+        (
+            "contact_right",
+            "dp_contact_right",
+            "invert_contact_right",
+            f"{label} rechts",
+        ),
+    ]
+    result: list[HomeKitAccessorySpec] = []
+    for prop, dp_key, invert_key, acc_label in specs:
+        dp = cfg.get(dp_key)
+        if not dp:
+            continue
+        acc = HomeKitAccessorySpec(
+            name_key=slugify(acc_label),
+            apple_home_name=acc_label,
+            type="ContactSensor",
+            widget_id=widget.get("id"),
+            widget_type=widget.get("type"),
+        )
+        acc.states["contact"] = _state(
+            opts, floor, room, acc_label, "contact", "boolean", "FROM_OBS"
+        )
+        acc.obs.status_dp_id = str(dp)
+        acc.obs.binding_direction = "FROM_OBS"
+        acc.obs.extra["invert"] = _bool_opt(cfg.get(invert_key))
+        acc.obs.extra["source"] = prop
+        result.append(acc)
+    if result:
+        return result
+    acc = HomeKitAccessorySpec(
+        name_key=slugify(label),
+        apple_home_name=label,
+        type="ContactSensor",
+        widget_id=widget.get("id"),
+        widget_type=widget.get("type"),
+        warnings=["Kein Kontakt-Datenpunkt im Fenster-Widget erkannt."],
+    )
+    acc.states["contact"] = _state(
+        opts, floor, room, label, "contact", "boolean", "FROM_OBS"
+    )
+    return [acc]
+
+
+def _rolladen_accessory(
+    widget: dict[str, Any],
+    floor: str,
+    room: str,
+    opts: HomeKitPreviewOptions,
+    knx_index: dict[str, dict[str, Any]],
+) -> HomeKitAccessorySpec:
+    label = _display_label(widget, "Rollo")
+    cfg = widget.get("config") or {}
+    acc = HomeKitAccessorySpec(
+        name_key=slugify(label),
+        apple_home_name=label,
+        type="WindowCovering",
+        widget_id=widget.get("id"),
+        widget_type=widget.get("type"),
+    )
+    target_dp = cfg.get("dp_position")
+    status_dp = cfg.get("dp_position_status") or target_dp
+    _set_obs_from_dps(
+        acc,
+        str(target_dp) if target_dp else None,
+        str(status_dp) if status_dp else None,
+        knx_index,
+    )
+    acc.states["current_position"] = _state(
+        opts, floor, room, label, "current_position", "number", "FROM_OBS"
+    )
+    acc.states["target_position"] = _state(
+        opts, floor, room, label, "target_position", "number", "BOTH"
+    )
+    acc.states["position_state"] = _state(
+        opts,
+        floor,
+        room,
+        label,
+        "position_state",
+        "number",
+        "FROM_OBS",
+        initial_value=2,
+        notes=["Phase-1-Default ohne Bewegungsrueckmeldung: 2 = stopped."],
+    )
+    if cfg.get("dp_stop"):
+        acc.states["stop"] = _state(
+            opts,
+            floor,
+            room,
+            label,
+            "stop",
+            "boolean",
+            "BOTH",
+            notes=["Interner Fallback-State, kein Yahka-Mapping."],
+        )
+        acc.obs.extra["stop_dp_id"] = cfg.get("dp_stop")
+    acc.warnings.append("Rolladensteuerung vor Freigabe pro Aktor einzeln pruefen.")
+    return acc
+
+
+def _rtr_accessory(
+    widget: dict[str, Any],
+    floor: str,
+    room: str,
+    opts: HomeKitPreviewOptions,
+) -> HomeKitAccessorySpec:
+    label = _display_label(widget, "Heizung")
+    cfg = widget.get("config") or {}
+    acc = HomeKitAccessorySpec(
+        name_key=slugify(label),
+        apple_home_name=label,
+        type="Thermostat",
+        widget_id=widget.get("id"),
+        widget_type=widget.get("type"),
+    )
+    acc.states["current_temperature"] = _state(
+        opts, floor, room, label, "current_temperature", "number", "FROM_OBS"
+    )
+    acc.states["target_temperature"] = _state(
+        opts,
+        floor,
+        room,
+        label,
+        "target_temperature",
+        "number",
+        "BOTH",
+        notes=["Clamp fuer HomeKit: 10..38 Grad Celsius."],
+    )
+    acc.states["current_heating_cooling_state"] = _state(
+        opts,
+        floor,
+        room,
+        label,
+        "current_heating_cooling_state",
+        "number",
+        "FROM_OBS",
+        notes=["Aus KNX DPT1.100 Heizbedarf oder heating_active ableiten."],
+    )
+    acc.states["target_heating_cooling_state"] = _state(
+        opts,
+        floor,
+        room,
+        label,
+        "target_heating_cooling_state",
+        "number",
+        "BOTH",
+        notes=["DPT20/HVAC-Betriebsmodus auf HomeKit-Zielmodus abbilden."],
+    )
+    acc.obs.switch_dp_id = str(widget.get("datapoint_id") or "") or None
+    acc.obs.status_dp_id = str(cfg.get("actual_temp_dp_id") or "") or None
+    acc.obs.extra.update(
+        {
+            "actual_temp_dp_id": cfg.get("actual_temp_dp_id"),
+            "knx_hvac_mode_dp_id": cfg.get("mode_dp_id"),
+            "target_temperature_range": [10, 38],
+            "target_temperature_step": cfg.get("step", 0.5),
+        }
+    )
+    if not cfg.get("actual_temp_dp_id"):
+        acc.warnings.append(
+            "Kein Isttemperatur-DP erkannt: ggf. nur TemperatureSensor anlegen."
+        )
+    acc.warnings.append("Sollwert-Roundtrip/Rundung pro RTR testen und dokumentieren.")
+    return acc
+
+
+def _value_sensor_accessory(
+    widget: dict[str, Any],
+    floor: str,
+    room: str,
+    opts: HomeKitPreviewOptions,
+    dp_index: dict[str, dict[str, Any]],
+) -> HomeKitAccessorySpec | None:
+    dp = _dp_id(widget)
+    if not dp:
+        return None
+    dp_info = dp_index.get(dp, {})
+    unit = (dp_info.get("unit") or "").lower()
+    name = _display_label(widget, dp_info.get("name") or "Sensor")
+    haystack = f"{name} {unit} {' '.join(dp_info.get('tags') or [])}".lower()
+    if "°c" in haystack or "temp" in haystack:
+        typ = "TemperatureSensor"
+        prop = "current_temperature"
+    elif "%" in haystack and ("feuchte" in haystack or "humid" in haystack):
+        typ = "HumiditySensor"
+        prop = "current_relative_humidity"
+    else:
+        return None
+    acc = HomeKitAccessorySpec(
+        name_key=slugify(name),
+        apple_home_name=name,
+        type=typ,
+        widget_id=widget.get("id"),
+        widget_type=widget.get("type"),
+    )
+    acc.states[prop] = _state(opts, floor, room, name, prop, "number", "FROM_OBS")
+    acc.obs.status_dp_id = dp
+    acc.obs.binding_direction = "FROM_OBS"
+    return acc
+
+
+def _unsupported_accessory(
+    widget: dict[str, Any], floor: str, room: str
+) -> HomeKitAccessorySpec:
+    label = _display_label(widget, widget.get("type") or "Widget")
+    return HomeKitAccessorySpec(
+        name_key=slugify(label),
+        apple_home_name=label,
+        type="Unsupported",
+        widget_id=widget.get("id"),
+        widget_type=widget.get("type"),
+        warnings=[
+            f"Widget-Typ {widget.get('type')!r} wird nicht automatisch nach HomeKit gemappt."
+        ],
+    )
+
+
+def _accessories_for_widget(
+    widget: dict[str, Any],
+    floor: str,
+    room: str,
+    opts: HomeKitPreviewOptions,
+    dp_index: dict[str, dict[str, Any]],
+    knx_index: dict[str, dict[str, Any]],
+) -> list[HomeKitAccessorySpec]:
+    typ = widget.get("type")
+    if typ == "Licht":
+        return [_light_accessory(widget, floor, room, opts, knx_index)]
+    if typ == "Toggle":
+        return [_toggle_accessory(widget, floor, room, opts, knx_index, dp_index)]
+    if typ == "Fenster":
+        return _contact_accessories(widget, floor, room, opts)
+    if typ == "Rolladen":
+        return [_rolladen_accessory(widget, floor, room, opts, knx_index)]
+    if typ == "RTR":
+        return [_rtr_accessory(widget, floor, room, opts)]
+    if typ == "ValueDisplay":
+        sensor = _value_sensor_accessory(widget, floor, room, opts, dp_index)
+        return [sensor] if sensor else [_unsupported_accessory(widget, floor, room)]
+    return [_unsupported_accessory(widget, floor, room)]
+
+
+def _summarize(rooms: list[HomeKitRoomSpec], limit: int) -> HomeKitPreviewSummary:
+    summary = HomeKitPreviewSummary(rooms=len(rooms))
+    for room in rooms:
+        for acc in room.accessories:
+            summary.accessories += 1
+            if acc.warnings:
+                summary.needs_manual_review += 1
+            match acc.type:
+                case "Lightbulb":
+                    summary.lightbulb += 1
+                case "Outlet":
+                    summary.outlet += 1
+                case "Switch":
+                    summary.switch += 1
+                case "ContactSensor":
+                    summary.contact_sensor += 1
+                case "WindowCovering":
+                    summary.window_covering += 1
+                case "Thermostat":
+                    summary.thermostat += 1
+                case "TemperatureSensor":
+                    summary.temperature_sensor += 1
+                case "HumiditySensor":
+                    summary.humidity_sensor += 1
+                case _:
+                    summary.unsupported += 1
+    summary.exceeds_single_bridge_limit = summary.accessories > limit
+    summary.recommended_bridges = max(1, (summary.accessories + limit - 1) // limit)
+    return summary
+
+
+def _system_states() -> list[HomeKitSystemStateSpec]:
+    return [
+        HomeKitSystemStateSpec(
+            id="0_userdata.0.obs.system.online",
+            data_type="boolean",
+            writer="OBS",
+            notes=["Heartbeat: true solange OBS laeuft."],
+        ),
+        HomeKitSystemStateSpec(
+            id="0_userdata.0.obs.system.last_seen",
+            data_type="string",
+            writer="OBS",
+            notes=[
+                "Heartbeat-Timestamp, Fallback nach 30..60 Sekunden ohne Aktualisierung."
+            ],
+        ),
+        HomeKitSystemStateSpec(
+            id="0_userdata.0.obs.system.iobroker_adapter_connected",
+            data_type="boolean",
+            writer="ioBroker Script",
+            source="system.adapter.obs.0.connected",
+            notes=["Instanznummer an reale OBS/ioBroker-Adapterinstanz anpassen."],
+        ),
+        HomeKitSystemStateSpec(
+            id="0_userdata.0.obs.system.fallback_active",
+            data_type="boolean",
+            writer="ioBroker Script",
+            notes=[
+                "Nur aktiv, wenn Heartbeat und Adapter-Gesundheit Ausfall signalisieren."
+            ],
+        ),
+    ]
+
+
+def _backup_items() -> list[str]:
+    return [
+        "HomeKit/Yahka-Mapping-Datei in einem versionierten Backup-Pfad sichern",
+        "ioBroker 0_userdata.0.obs.* States persistent sichern",
+        "Yahka-Konfiguration",
+        "Yahka-Pairing-Datenpfad der Installation sichern",
+        "ioBroker-Scripts fuer Heartbeat, Adapterstatus und Fallback sichern",
+        "KNX-/Fallback-Pfad separat pruefen und dokumentieren",
+    ]
+
+
+def _obs_data_type(data_type: str) -> str:
+    return {
+        "boolean": "BOOLEAN",
+        "bool": "BOOLEAN",
+        "number": "FLOAT",
+        "float": "FLOAT",
+        "integer": "INTEGER",
+        "int": "INTEGER",
+        "string": "STRING",
+    }.get(data_type.lower(), "STRING")
+
+
+def _source_data_type(data_type: str) -> str | None:
+    return {
+        "BOOLEAN": "bool",
+        "FLOAT": "float",
+        "INTEGER": "int",
+        "STRING": "string",
+    }.get(_obs_data_type(data_type))
+
+
+def _state_role(accessory_type: str, state_key: str) -> str:
+    if state_key == "on":
+        return "switch"
+    if accessory_type == "ContactSensor":
+        return "sensor.window"
+    if "temperature" in state_key:
+        return "level.temperature"
+    if "position" in state_key:
+        return "level.blind"
+    if state_key == "position_state":
+        return "indicator.state"
+    return "state"
+
+
+def _restore_tests() -> list[str]:
+    return [
+        "Yahka-Daten zurueckspielen und pruefen, dass Apple Home die Bridge ohne neues Pairing erkennt",
+        "Mapping-Datei und 0_userdata.0.obs.* States wiederherstellen",
+        "OBS starten und Re-Sync der ioBroker Home-States pruefen",
+        "Szenen und Automationen in Apple Home stichprobenartig pruefen",
+    ]
+
+
+async def build_preview(db: Database, opts: HomeKitPreviewOptions) -> HomeKitPreview:
+    rows = await _load_visu_rows(db)
+    root = _find_root(rows, opts)
+    if root is None:
+        raise ValueError(
+            f"VISU root not found: {opts.root_node_id or opts.source_visu_name}"
+        )
+
+    dp_index = await _load_dp_index(db)
+    knx_index = await _load_knx_index(db)
+    by_id = {row["id"]: row for row in rows}
+    descendants = _descendants(rows, root["id"])
+    rooms_by_key: dict[tuple[str, str], HomeKitRoomSpec] = {}
+    warnings: list[str] = []
+
+    for node in descendants:
+        if node.get("type") != "PAGE":
+            continue
+        widgets = _page_widgets(node)
+        if not widgets:
+            continue
+        path = _path_for(node, by_id, root["id"])
+        floor = path[0]["name"] if len(path) > 1 else "Allgemein"
+        room = path[-1]["name"]
+        room_key = slugify(room)
+        apple_room = f"{floor} {room}" if opts.room_strategy == "floor_prefix" else room
+        key = (floor, room)
+        room_spec = rooms_by_key.setdefault(
+            key,
+            HomeKitRoomSpec(
+                floor=floor,
+                room_key=room_key,
+                room_display_name=room,
+                apple_home_room=apple_room,
+            ),
+        )
+        for widget in widgets:
+            room_spec.accessories.extend(
+                _accessories_for_widget(widget, floor, room, opts, dp_index, knx_index)
+            )
+
+    rooms = list(rooms_by_key.values())
+    rooms.sort(key=lambda r: (r.floor, r.room_display_name))
+    summary = _summarize(rooms, opts.accessory_limit_per_bridge)
+    if summary.exceeds_single_bridge_limit:
+        warnings.append(
+            f"HomeKit-Bridge-Limit ueberschritten: {summary.accessories} Accessories, "
+            f"{summary.recommended_bridges} Yahka-Bridges empfohlen."
+        )
+
+    return HomeKitPreview(
+        project=opts.project,
+        source_visu=root["name"],
+        leading_iobroker={
+            "name": opts.leading_iobroker_name,
+            "host": opts.leading_iobroker_host,
+            "port": opts.leading_iobroker_port,
+            "role": "yahka_and_fallback",
+        },
+        room_strategy=opts.room_strategy,
+        accessory_limit_per_bridge=opts.accessory_limit_per_bridge,
+        rooms=rooms,
+        summary=summary,
+        warnings=warnings,
+        system_states=_system_states(),
+        backup_items=_backup_items(),
+        restore_tests=_restore_tests(),
+    )
+
+
+async def _existing_iobroker_bindings(
+    db: Database, instance_id: str
+) -> dict[str, tuple[str, str]]:
+    rows = await db.fetchall(
+        "SELECT id, datapoint_id, config FROM adapter_bindings WHERE adapter_instance_id=?",
+        (instance_id,),
+    )
+    result: dict[str, tuple[str, str]] = {}
+    for row in rows:
+        try:
+            cfg = json.loads(row["config"] or "{}")
+        except Exception:
+            continue
+        state_id = cfg.get("state_id")
+        if state_id:
+            result[str(state_id)] = (row["datapoint_id"], row["id"])
+    return result
+
+
+async def _create_iobroker_binding(
+    db: Database,
+    dp_id: str,
+    instance_id: str,
+    direction: str,
+    state: HomeKitStateSpec,
+) -> str:
+    row = await db.fetchone(
+        "SELECT adapter_type FROM adapter_instances WHERE id=?", (instance_id,)
+    )
+    if row is None:
+        raise ValueError(f"ioBroker instance not found: {instance_id}")
+    now = datetime.now(timezone.utc).isoformat()
+    binding_id = str(uuid.uuid4())
+    config: dict[str, Any] = {
+        "state_id": state.id,
+        "ack": True,
+    }
+    source_type = _source_data_type(state.data_type)
+    if source_type:
+        config["source_data_type"] = source_type
+    await db.execute_and_commit(
+        """INSERT INTO adapter_bindings
+           (id, datapoint_id, adapter_type, adapter_instance_id, direction, config, enabled,
+            created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?)""",
+        (
+            binding_id,
+            dp_id,
+            row["adapter_type"],
+            instance_id,
+            direction,
+            json.dumps(config),
+            now,
+            now,
+        ),
+    )
+    return binding_id
+
+
+def _target_datapoint_for_state(
+    accessory: HomeKitAccessorySpec, state_key: str
+) -> str | None:
+    """Return an existing OBS datapoint that should carry this HomeKit state.
+
+    The preferred rollout model is to attach Yahka/ioBroker states to the
+    existing KNX/ETS datapoint instead of creating a parallel HomeKit datapoint.
+    Only helper states without a KNX counterpart should remain standalone.
+    """
+    if state_key == "on":
+        return accessory.obs.switch_dp_id or accessory.obs.status_dp_id
+    if state_key in {
+        "contact",
+        "current_temperature",
+        "current_relative_humidity",
+        "current_position",
+        "current_heating_cooling_state",
+    }:
+        return accessory.obs.status_dp_id or accessory.obs.switch_dp_id
+    if state_key in {
+        "target_position",
+        "target_temperature",
+        "target_heating_cooling_state",
+    }:
+        return accessory.obs.switch_dp_id
+    if state_key == "stop":
+        value = accessory.obs.extra.get("stop_dp_id")
+        return str(value) if value else None
+    return None
+
+
+async def _datapoint_exists(db: Database, dp_id: str | None) -> bool:
+    if not dp_id:
+        return False
+    row = await db.fetchone("SELECT id FROM datapoints WHERE id=?", (dp_id,))
+    return row is not None
+
+
+async def _merge_datapoint_metadata(
+    db: Database,
+    dp_id: str,
+    data_type: str,
+    tags: list[str],
+) -> None:
+    row = await db.fetchone(
+        "SELECT tags, data_type FROM datapoints WHERE id=?", (dp_id,)
+    )
+    if row is None:
+        return
+    try:
+        current_tags = json.loads(row["tags"] or "[]")
+    except Exception:
+        current_tags = []
+    merged_tags: list[str] = []
+    for tag in [*current_tags, *tags]:
+        if tag and tag not in merged_tags:
+            merged_tags.append(tag)
+    await db.execute_and_commit(
+        "UPDATE datapoints SET data_type=?, tags=?, updated_at=? WHERE id=?",
+        (
+            data_type if row["data_type"] == "UNKNOWN" else row["data_type"],
+            json.dumps(merged_tags),
+            datetime.now(timezone.utc).isoformat(),
+            dp_id,
+        ),
+    )
+
+
+async def _set_knx_binding_direction(
+    db: Database,
+    dp_id: str | None,
+    direction: str,
+) -> None:
+    if not dp_id:
+        return
+    await db.execute_and_commit(
+        """UPDATE adapter_bindings
+           SET direction=?, updated_at=?
+           WHERE datapoint_id=? AND adapter_type='KNX'""",
+        (direction, datetime.now(timezone.utc).isoformat(), dp_id),
+    )
+
+
+async def _normalize_knx_directions_for_accessory(
+    db: Database, accessory: HomeKitAccessorySpec
+) -> None:
+    if accessory.obs.switch_dp_id:
+        await _set_knx_binding_direction(db, accessory.obs.switch_dp_id, "DEST")
+    if (
+        accessory.obs.status_dp_id
+        and accessory.obs.status_dp_id != accessory.obs.switch_dp_id
+    ):
+        await _set_knx_binding_direction(db, accessory.obs.status_dp_id, "SOURCE")
+
+
+async def _ensure_iobroker_state(
+    instance_id: str,
+    accessory: HomeKitAccessorySpec,
+    state_key: str,
+    state: HomeKitStateSpec,
+) -> bool:
+    from obs.adapters import registry as adapter_registry
+
+    instance = adapter_registry.get_instance_by_id(instance_id)
+    if instance is None or not getattr(instance, "connected", False):
+        raise RuntimeError("ioBroker-Instanz ist nicht verbunden")
+    if not hasattr(instance, "ensure_state"):
+        raise RuntimeError("ioBroker-Adapter kann States nicht anlegen")
+
+    await instance.ensure_state(
+        {
+            "state_id": state.id,
+            "data_type": _obs_data_type(state.data_type),
+            "name": f"{accessory.apple_home_name} {state_key}",
+            "role": _state_role(accessory.type, state_key),
+            "read": True,
+            "write": state.binding_direction == "BOTH",
+            "initial_value": state.initial_value,
+        }
+    )
+    return True
+
+
+async def apply_mapping(
+    db: Database, registry: Any, request: HomeKitApplyRequest
+) -> HomeKitApplyResult:
+    """Create OBS datapoints and ioBroker bindings from a preview.
+
+    The function is idempotent by ioBroker state_id: existing bindings for the
+    selected ioBroker instance are skipped instead of duplicated.
+    """
+    instance_id = str(request.iobroker_instance_id)
+    instance_row = await db.fetchone(
+        "SELECT * FROM adapter_instances WHERE id=?", (instance_id,)
+    )
+    if instance_row is None:
+        raise ValueError(f"ioBroker instance not found: {instance_id}")
+    if instance_row["adapter_type"] != "IOBROKER":
+        raise ValueError("HomeKit apply requires an IOBROKER adapter instance")
+
+    preview = await build_preview(db, request)
+    existing = await _existing_iobroker_bindings(db, instance_id)
+    selected_rooms = set(request.room_keys)
+    result = HomeKitApplyResult(
+        dry_run=request.dry_run, preview_summary=preview.summary
+    )
+    selected_rooms_for_summary: list[HomeKitRoomSpec] = []
+
+    for room in preview.rooms:
+        if (
+            selected_rooms
+            and room.room_key not in selected_rooms
+            and room.apple_home_room not in selected_rooms
+        ):
+            continue
+        selected_room = room.model_copy(update={"accessories": []})
+        selected_rooms_for_summary.append(selected_room)
+        for accessory in room.accessories:
+            selected_room.accessories.append(accessory)
+            if accessory.type == "Unsupported" and not request.include_unsupported:
+                result.skipped_unsupported += 1
+                result.items.append(
+                    HomeKitApplyItem(
+                        state_id="",
+                        room=room.apple_home_room,
+                        accessory=accessory.apple_home_name,
+                        accessory_type=accessory.type,
+                        state_key="",
+                        data_type="",
+                        binding_direction="FROM_OBS",
+                        obs_binding_direction="DEST",
+                        action="skip_unsupported",
+                        message="Unsupported widget is not imported automatically.",
+                    )
+                )
+                continue
+            for state_key, state in accessory.states.items():
+                if state.id in existing:
+                    dp_id, binding_id = existing[state.id]
+                    iobroker_state_created = False
+                    message = None
+                    if request.create_iobroker_states and not request.dry_run:
+                        try:
+                            iobroker_state_created = await _ensure_iobroker_state(
+                                instance_id,
+                                accessory,
+                                state_key,
+                                state,
+                            )
+                            result.created_iobroker_states += 1
+                        except Exception as exc:
+                            message = str(exc)
+                            result.errors.append(f"{state.id}: {exc}")
+                    result.skipped_existing += 1
+                    result.items.append(
+                        HomeKitApplyItem(
+                            state_id=state.id,
+                            room=room.apple_home_room,
+                            accessory=accessory.apple_home_name,
+                            accessory_type=accessory.type,
+                            state_key=state_key,
+                            data_type=_obs_data_type(state.data_type),
+                            binding_direction=state.binding_direction,
+                            obs_binding_direction=state.obs_binding_direction,
+                            action="skip_existing",
+                            datapoint_id=dp_id,
+                            binding_id=binding_id,
+                            iobroker_state_created=iobroker_state_created,
+                            message=message,
+                        )
+                    )
+                    continue
+
+                datapoint_tags = [
+                    "homekit",
+                    "yahka",
+                    "obs-home",
+                    slugify(request.project),
+                    slugify(room.floor),
+                    room.room_key,
+                    slugify(accessory.type),
+                ]
+                target_dp_id = _target_datapoint_for_state(accessory, state_key)
+                reuse_existing_dp = await _datapoint_exists(db, target_dp_id)
+                item = HomeKitApplyItem(
+                    state_id=state.id,
+                    room=room.apple_home_room,
+                    accessory=accessory.apple_home_name,
+                    accessory_type=accessory.type,
+                    state_key=state_key,
+                    data_type=_obs_data_type(state.data_type),
+                    binding_direction=state.binding_direction,
+                    obs_binding_direction=state.obs_binding_direction,
+                    action="reuse_existing" if reuse_existing_dp else "create",
+                    datapoint_id=target_dp_id if reuse_existing_dp else None,
+                    message="Bestehendes KNX/ETS-OBS-Objekt wird wiederverwendet."
+                    if reuse_existing_dp
+                    else None,
+                )
+                if request.dry_run:
+                    result.items.append(item)
+                    continue
+
+                try:
+                    if reuse_existing_dp and target_dp_id:
+                        await _merge_datapoint_metadata(
+                            db,
+                            target_dp_id,
+                            _obs_data_type(state.data_type),
+                            datapoint_tags,
+                        )
+                        await _normalize_knx_directions_for_accessory(db, accessory)
+                        dp_id = target_dp_id
+                    else:
+                        from obs.models.datapoint import DataPointCreate
+
+                        dp = await registry.create(
+                            DataPointCreate(
+                                name=f"{room.apple_home_room} {accessory.apple_home_name} {state_key}",
+                                data_type=_obs_data_type(state.data_type),
+                                tags=datapoint_tags,
+                                persist_value=state.persistent,
+                                record_history=False,
+                            )
+                        )
+                        dp_id = str(dp.id)
+                        item.datapoint_id = dp_id
+                        result.created_datapoints += 1
+
+                    item.binding_id = await _create_iobroker_binding(
+                        db,
+                        dp_id,
+                        instance_id,
+                        state.obs_binding_direction,
+                        state,
+                    )
+                    result.created_bindings += 1
+                    existing[state.id] = (dp_id, item.binding_id)
+
+                    if request.create_iobroker_states:
+                        item.iobroker_state_created = await _ensure_iobroker_state(
+                            instance_id,
+                            accessory,
+                            state_key,
+                            state,
+                        )
+                        result.created_iobroker_states += 1
+                except Exception as exc:
+                    item.action = "error"
+                    item.message = str(exc)
+                    result.errors.append(f"{state.id}: {exc}")
+                result.items.append(item)
+
+    if not request.dry_run:
+        from obs.adapters.registry import reload_instance_bindings
+
+        await reload_instance_bindings(instance_id, db)
+
+    result.apply_summary = _summarize(
+        selected_rooms_for_summary, request.accessory_limit_per_bridge
+    )
+    return result

--- a/tests/unit/test_homekit_yahka.py
+++ b/tests/unit/test_homekit_yahka.py
@@ -1,0 +1,508 @@
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+import pytest_asyncio
+
+from obs.db.database import Database
+from obs.homekit.yahka import (
+    HomeKitApplyRequest,
+    HomeKitPreviewOptions,
+    apply_mapping,
+    build_preview,
+    slugify,
+)
+
+
+pytestmark = pytest.mark.asyncio
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+async def _insert_dp(
+    db: Database,
+    dp_id: str,
+    name: str,
+    data_type: str = "BOOLEAN",
+    unit: str | None = None,
+) -> None:
+    await db.execute(
+        """INSERT INTO datapoints
+           (id, name, data_type, unit, tags, mqtt_topic, mqtt_alias,
+            created_at, updated_at, persist_value, record_history)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            dp_id,
+            name,
+            data_type,
+            unit,
+            json.dumps(["knx"]),
+            f"dp/{dp_id}/value",
+            None,
+            _now(),
+            _now(),
+            1,
+            1,
+        ),
+    )
+
+
+async def _insert_knx_binding(
+    db: Database,
+    dp_id: str,
+    group_address: str,
+    state_group_address: str | None = None,
+    direction: str = "BOTH",
+) -> None:
+    await db.execute(
+        """INSERT INTO adapter_bindings
+           (id, datapoint_id, adapter_type, adapter_instance_id, direction, config, enabled,
+            created_at, updated_at)
+           VALUES (?, ?, 'KNX', ?, ?, ?, 1, ?, ?)""",
+        (
+            str(uuid.uuid4()),
+            dp_id,
+            str(uuid.uuid4()),
+            direction,
+            json.dumps(
+                {
+                    "group_address": group_address,
+                    "state_group_address": state_group_address,
+                    "dpt_id": "DPT1.001",
+                }
+            ),
+            _now(),
+            _now(),
+        ),
+    )
+
+
+async def _insert_iobroker_instance(db: Database, instance_id: str) -> None:
+    await db.execute(
+        """INSERT INTO adapter_instances
+           (id, adapter_type, name, config, enabled, created_at, updated_at)
+           VALUES (?, 'IOBROKER', 'ioBroker', '{}', 1, ?, ?)""",
+        (instance_id, _now(), _now()),
+    )
+
+
+async def _insert_node(
+    db: Database,
+    node_id: str,
+    name: str,
+    parent_id: str | None,
+    node_type: str,
+    widgets: list[dict] | None = None,
+    order: int = 0,
+) -> None:
+    page_config = json.dumps(
+        {
+            "grid_cols": 12,
+            "grid_row_height": 80,
+            "grid_cell_width": 80,
+            "background": None,
+            "widgets": widgets or [],
+        }
+    )
+    await db.execute(
+        """INSERT INTO visu_nodes
+           (id, parent_id, name, type, node_order, icon, access, access_pin,
+            page_config, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, NULL, NULL, NULL, ?, ?, ?)""",
+        (node_id, parent_id, name, node_type, order, page_config, _now(), _now()),
+    )
+
+
+@pytest_asyncio.fixture
+async def db() -> Database:
+    database = Database(":memory:")
+    await database.connect()
+    try:
+        yield database
+    finally:
+        await database.disconnect()
+
+
+async def test_slugify_normalizes_german_names() -> None:
+    assert slugify("EG Küche Licht Decke") == "eg_kueche_licht_decke"
+    assert slugify("Außen Büro") == "aussen_buero"
+
+
+async def test_build_preview_maps_visu_widgets_with_explicit_binding_directions(
+    db: Database,
+) -> None:
+    switch_dp = str(uuid.uuid4())
+    status_dp = str(uuid.uuid4())
+    temp_dp = str(uuid.uuid4())
+    actual_temp_dp = str(uuid.uuid4())
+    contact_dp = str(uuid.uuid4())
+
+    await _insert_dp(db, switch_dp, "Küche Licht schreiben")
+    await _insert_dp(db, status_dp, "Küche Licht Status")
+    await _insert_dp(db, temp_dp, "Küche Solltemperatur", "FLOAT", "°C")
+    await _insert_dp(db, actual_temp_dp, "Küche Isttemperatur", "FLOAT", "°C")
+    await _insert_dp(db, contact_dp, "Küche Fenster", "BOOLEAN")
+
+    await _insert_knx_binding(db, switch_dp, "1/1/1", "1/1/2", "BOTH")
+    await _insert_knx_binding(db, status_dp, "1/1/2", None, "SOURCE")
+
+    root_id = "root"
+    floor_id = "eg"
+    page_id = "kueche"
+    await _insert_node(db, root_id, "Home", None, "LOCATION")
+    await _insert_node(db, floor_id, "EG", root_id, "LOCATION")
+    await _insert_node(
+        db,
+        page_id,
+        "Küche",
+        floor_id,
+        "PAGE",
+        widgets=[
+            {
+                "id": "w-light",
+                "type": "Licht",
+                "config": {
+                    "label": "Licht",
+                    "dp_switch": switch_dp,
+                    "dp_switch_status": status_dp,
+                },
+            },
+            {
+                "id": "w-rtr",
+                "type": "RTR",
+                "datapoint_id": temp_dp,
+                "config": {
+                    "label": "Heizung",
+                    "actual_temp_dp_id": actual_temp_dp,
+                    "step": 0.5,
+                },
+            },
+            {
+                "id": "w-window",
+                "type": "Fenster",
+                "config": {
+                    "label": "Fenster",
+                    "dp_contact": contact_dp,
+                    "invert_contact": True,
+                },
+            },
+        ],
+    )
+    await db.commit()
+
+    preview = await build_preview(db, HomeKitPreviewOptions(root_node_id=root_id))
+
+    assert preview.summary.rooms == 1
+    assert preview.summary.accessories == 3
+    room = preview.rooms[0]
+    assert room.apple_home_room == "EG Küche"
+
+    light = next(a for a in room.accessories if a.type == "Lightbulb")
+    assert light.states["on"].binding_direction == "BOTH"
+    assert light.states["on"].obs_binding_direction == "BOTH"
+    assert light.obs.status_dp_id == status_dp
+    assert light.obs.status_confirms_write is True
+    assert light.obs.optimistic_update is False
+    assert light.obs.knx_write_ga == "1/1/1"
+    assert light.obs.knx_status_ga == "1/1/2"
+
+    thermostat = next(a for a in room.accessories if a.type == "Thermostat")
+    assert thermostat.states["current_temperature"].binding_direction == "FROM_OBS"
+    assert thermostat.states["current_temperature"].obs_binding_direction == "DEST"
+    assert thermostat.states["target_temperature"].binding_direction == "BOTH"
+    assert thermostat.obs.extra["target_temperature_range"] == [10, 38]
+    assert "Sollwert-Roundtrip" in " ".join(thermostat.warnings)
+
+    contact = next(a for a in room.accessories if a.type == "ContactSensor")
+    assert contact.states["contact"].binding_direction == "FROM_OBS"
+    assert contact.obs.extra["invert"] is True
+
+
+async def test_build_preview_warns_when_homekit_bridge_limit_is_exceeded(
+    db: Database,
+) -> None:
+    root_id = "root"
+    floor_id = "eg"
+    page_id = "kueche"
+    widgets = [
+        {"id": f"w-{i}", "type": "Licht", "config": {"label": f"Licht {i}"}}
+        for i in range(4)
+    ]
+    await _insert_node(db, root_id, "Home", None, "LOCATION")
+    await _insert_node(db, floor_id, "EG", root_id, "LOCATION")
+    await _insert_node(db, page_id, "Küche", floor_id, "PAGE", widgets=widgets)
+    await db.commit()
+
+    preview = await build_preview(
+        db,
+        HomeKitPreviewOptions(root_node_id=root_id, accessory_limit_per_bridge=3),
+    )
+
+    assert preview.summary.accessories == 4
+    assert preview.summary.exceeds_single_bridge_limit is True
+    assert preview.summary.recommended_bridges == 2
+    assert preview.warnings
+
+
+async def test_apply_mapping_dry_run_does_not_create_datapoints(db: Database) -> None:
+    iobroker_id = str(uuid.uuid4())
+    await _insert_iobroker_instance(db, iobroker_id)
+    root_id = "root"
+    floor_id = "eg"
+    page_id = "kueche"
+    await _insert_node(db, root_id, "Home", None, "LOCATION")
+    await _insert_node(db, floor_id, "EG", root_id, "LOCATION")
+    await _insert_node(
+        db,
+        page_id,
+        "Küche",
+        floor_id,
+        "PAGE",
+        widgets=[
+            {"id": "w-light", "type": "Licht", "config": {"label": "Licht"}},
+        ],
+    )
+    await db.commit()
+
+    class FailingRegistry:
+        async def create(self, payload):  # pragma: no cover - must not be called
+            raise AssertionError("dry_run must not create datapoints")
+
+    result = await apply_mapping(
+        db,
+        FailingRegistry(),
+        HomeKitApplyRequest(
+            root_node_id=root_id,
+            iobroker_instance_id=uuid.UUID(iobroker_id),
+            dry_run=True,
+        ),
+    )
+
+    assert result.dry_run is True
+    assert result.apply_summary.accessories == 1
+    assert result.preview_summary.accessories == 1
+    assert result.created_datapoints == 0
+    assert [item.action for item in result.items] == ["create"]
+    rows = await db.fetchall("SELECT * FROM datapoints")
+    assert rows == []
+
+
+async def test_apply_mapping_creates_datapoints_bindings_and_is_idempotent(
+    db: Database,
+) -> None:
+    from unittest.mock import AsyncMock, MagicMock
+    from obs.core.registry import DataPointRegistry
+
+    iobroker_id = str(uuid.uuid4())
+    await _insert_iobroker_instance(db, iobroker_id)
+    root_id = "root"
+    floor_id = "eg"
+    page_id = "kueche"
+    await _insert_node(db, root_id, "Home", None, "LOCATION")
+    await _insert_node(db, floor_id, "EG", root_id, "LOCATION")
+    await _insert_node(
+        db,
+        page_id,
+        "Küche",
+        floor_id,
+        "PAGE",
+        widgets=[
+            {"id": "w-light", "type": "Licht", "config": {"label": "Licht"}},
+        ],
+    )
+    await db.commit()
+
+    mqtt = MagicMock()
+    mqtt.publish_value = AsyncMock()
+    bus = MagicMock()
+    registry = DataPointRegistry(db, mqtt, bus)
+    await registry.load_from_db()
+
+    request = HomeKitApplyRequest(
+        root_node_id=root_id,
+        iobroker_instance_id=uuid.UUID(iobroker_id),
+        dry_run=False,
+    )
+    first = await apply_mapping(db, registry, request)
+
+    assert first.apply_summary.accessories == 1
+    assert first.created_datapoints == 1
+    assert first.created_bindings == 1
+    assert first.items[0].state_id == "0_userdata.0.obs.home.eg.kueche.licht.on"
+    assert first.items[0].obs_binding_direction == "BOTH"
+
+    rows = await db.fetchall("SELECT * FROM adapter_bindings")
+    assert len(rows) == 1
+    assert rows[0]["direction"] == "BOTH"
+    cfg = json.loads(rows[0]["config"])
+    assert cfg["state_id"] == first.items[0].state_id
+    assert cfg["ack"] is True
+    assert cfg["source_data_type"] == "bool"
+
+    second = await apply_mapping(db, registry, request)
+    assert second.created_datapoints == 0
+    assert second.created_bindings == 0
+    assert second.skipped_existing == 1
+
+
+async def test_apply_mapping_reuses_existing_knx_datapoints(db: Database) -> None:
+    from unittest.mock import AsyncMock, MagicMock
+    from obs.core.registry import DataPointRegistry
+
+    iobroker_id = str(uuid.uuid4())
+    switch_dp = str(uuid.uuid4())
+    status_dp = str(uuid.uuid4())
+    await _insert_iobroker_instance(db, iobroker_id)
+    await _insert_dp(db, switch_dp, "Küche Licht", "UNKNOWN")
+    await _insert_dp(db, status_dp, "Küche Licht Status", "BOOLEAN")
+    await _insert_knx_binding(db, switch_dp, "1/2/3", direction="BOTH")
+    await _insert_knx_binding(db, status_dp, "1/2/4", direction="BOTH")
+
+    root_id = "root"
+    floor_id = "eg"
+    page_id = "kueche"
+    await _insert_node(db, root_id, "Home", None, "LOCATION")
+    await _insert_node(db, floor_id, "EG", root_id, "LOCATION")
+    await _insert_node(
+        db,
+        page_id,
+        "Küche",
+        floor_id,
+        "PAGE",
+        widgets=[
+            {
+                "id": "w-light",
+                "type": "Licht",
+                "config": {
+                    "label": "Licht",
+                    "dp_switch": switch_dp,
+                    "dp_switch_status": status_dp,
+                },
+            },
+        ],
+    )
+    await db.commit()
+
+    mqtt = MagicMock()
+    mqtt.publish_value = AsyncMock()
+    bus = MagicMock()
+    registry = DataPointRegistry(db, mqtt, bus)
+    await registry.load_from_db()
+
+    result = await apply_mapping(
+        db,
+        registry,
+        HomeKitApplyRequest(
+            root_node_id=root_id,
+            iobroker_instance_id=uuid.UUID(iobroker_id),
+            dry_run=False,
+        ),
+    )
+
+    assert result.created_datapoints == 0
+    assert result.created_bindings == 1
+    assert result.items[0].action == "reuse_existing"
+    assert result.items[0].datapoint_id == switch_dp
+
+    dps = await db.fetchall("SELECT * FROM datapoints ORDER BY name")
+    assert len(dps) == 2
+    switch_row = next(row for row in dps if row["id"] == switch_dp)
+    assert switch_row["data_type"] == "BOOLEAN"
+    assert "homekit" in json.loads(switch_row["tags"])
+
+    iobroker_rows = await db.fetchall(
+        "SELECT * FROM adapter_bindings WHERE adapter_type='IOBROKER'"
+    )
+    assert len(iobroker_rows) == 1
+    assert iobroker_rows[0]["datapoint_id"] == switch_dp
+    assert iobroker_rows[0]["direction"] == "BOTH"
+
+    knx_rows = await db.fetchall(
+        "SELECT * FROM adapter_bindings WHERE adapter_type='KNX'"
+    )
+    directions = {row["datapoint_id"]: row["direction"] for row in knx_rows}
+    assert directions[switch_dp] == "DEST"
+    assert directions[status_dp] == "SOURCE"
+
+
+async def test_apply_mapping_can_create_iobroker_states_for_existing_bindings(
+    db: Database, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from unittest.mock import AsyncMock, MagicMock
+    from obs.core.registry import DataPointRegistry
+
+    iobroker_id = str(uuid.uuid4())
+    await _insert_iobroker_instance(db, iobroker_id)
+    root_id = "root"
+    floor_id = "eg"
+    page_id = "kueche"
+    await _insert_node(db, root_id, "Home", None, "LOCATION")
+    await _insert_node(db, floor_id, "EG", root_id, "LOCATION")
+    await _insert_node(
+        db,
+        page_id,
+        "Küche",
+        floor_id,
+        "PAGE",
+        widgets=[
+            {"id": "w-light", "type": "Licht", "config": {"label": "Licht"}},
+        ],
+    )
+    await db.commit()
+
+    mqtt = MagicMock()
+    mqtt.publish_value = AsyncMock()
+    bus = MagicMock()
+    registry = DataPointRegistry(db, mqtt, bus)
+    await registry.load_from_db()
+
+    await apply_mapping(
+        db,
+        registry,
+        HomeKitApplyRequest(
+            root_node_id=root_id,
+            iobroker_instance_id=uuid.UUID(iobroker_id),
+            dry_run=False,
+        ),
+    )
+
+    class AdapterInstance:
+        connected = True
+
+        def __init__(self) -> None:
+            self.ensure_state = AsyncMock()
+
+    adapter = AdapterInstance()
+
+    def get_instance_by_id(instance_id: str):
+        assert instance_id == iobroker_id
+        return adapter
+
+    monkeypatch.setattr("obs.adapters.registry.get_instance_by_id", get_instance_by_id)
+
+    result = await apply_mapping(
+        db,
+        registry,
+        HomeKitApplyRequest(
+            root_node_id=root_id,
+            iobroker_instance_id=uuid.UUID(iobroker_id),
+            dry_run=False,
+            create_iobroker_states=True,
+        ),
+    )
+
+    assert result.created_datapoints == 0
+    assert result.created_bindings == 0
+    assert result.skipped_existing == 1
+    assert result.created_iobroker_states == 1
+    assert result.items[0].action == "skip_existing"
+    assert result.items[0].iobroker_state_created is True
+    adapter.ensure_state.assert_awaited_once()
+    payload = adapter.ensure_state.await_args.args[0]
+    assert payload["state_id"] == "0_userdata.0.obs.home.eg.kueche.licht.on"
+    assert payload["write"] is True

--- a/tests/unit/test_iobroker_adapters_api.py
+++ b/tests/unit/test_iobroker_adapters_api.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from obs.api.v1 import adapters as adapters_api
+from obs.api.v1.adapters import IoBrokerImportRequest
+
+
+class _FakeDb:
+    def __init__(self, row: dict, binding_rows: list[dict] | None = None):
+        self._row = row
+        self._binding_rows = binding_rows or []
+
+    async def fetchone(self, _query: str, _params: tuple):
+        return self._row
+
+    async def fetchall(self, query: str, _params: tuple):
+        if "FROM adapter_bindings" in query:
+            return self._binding_rows
+        return []
+
+
+@pytest.mark.asyncio
+async def test_browse_states_uses_running_instance_even_if_connected_flag_is_false(
+    monkeypatch,
+):
+    fake_instance = type("FakeIoBrokerInstance", (), {})()
+    fake_instance.connected = False
+    fake_instance.browse_states = AsyncMock(
+        return_value=[
+            {
+                "id": "hue.0.Küche_3.on",
+                "name": "Küche 3 On",
+                "type": "boolean",
+                "role": "switch.light",
+                "read": True,
+                "write": True,
+                "value": False,
+                "unit": None,
+            }
+        ]
+    )
+
+    monkeypatch.setattr(
+        adapters_api.adapter_registry,
+        "get_instance_by_id",
+        lambda _instance_id: fake_instance,
+    )
+
+    result = await adapters_api.iobroker_browse_states(
+        instance_id="96f4d53c-455d-47ff-a9d0-a9def24951ff",
+        q="Küche",
+        limit=10,
+        _user="admin",
+        db=_FakeDb({"adapter_type": "IOBROKER"}),
+    )
+
+    assert len(result) == 1
+    assert result[0].id == "hue.0.Küche_3.on"
+    fake_instance.browse_states.assert_awaited_once_with("Küche", 10)
+
+
+@pytest.mark.asyncio
+async def test_import_preview_uses_running_instance_even_if_connected_flag_is_false(
+    monkeypatch,
+):
+    fake_instance = type("FakeIoBrokerInstance", (), {})()
+    fake_instance.connected = False
+    fake_instance.browse_states = AsyncMock(
+        return_value=[
+            {
+                "id": "0_userdata.0.obs.home.eg.kueche.licht.on",
+                "name": "Küche Licht",
+                "type": "boolean",
+                "role": "switch.light",
+                "read": True,
+                "write": True,
+                "value": False,
+                "unit": None,
+            }
+        ]
+    )
+
+    monkeypatch.setattr(
+        adapters_api.adapter_registry,
+        "get_instance_by_id",
+        lambda _instance_id: fake_instance,
+    )
+
+    result = await adapters_api.iobroker_import_preview(
+        instance_id="96f4d53c-455d-47ff-a9d0-a9def24951ff",
+        body=IoBrokerImportRequest(
+            prefix="Küche",
+            direction="auto",
+            tags=["eg", "kueche"],
+            limit=10,
+        ),
+        _user="admin",
+        db=_FakeDb({"adapter_type": "IOBROKER"}),
+    )
+
+    assert len(result.preview) == 1
+    assert result.preview[0].state_id == "0_userdata.0.obs.home.eg.kueche.licht.on"
+    assert result.preview[0].exists is False
+    fake_instance.browse_states.assert_awaited_once_with("Küche", 10)


### PR DESCRIPTION
## Summary
This PR adds an experimental HomeKit/Yahka migration helper on top of the native ioBroker adapter.

The goal is not to move HomeKit into OBS or to replace Yahka. The goal is to let OBS use its existing VISU, datapoint, and binding model to generate a reviewable migration plan for Apple Home integrations that are still bridged through ioBroker/Yahka.

In short:
- OBS remains the source of structure
- ioBroker/Yahka remains the HomeKit bridge
- this PR adds preview/apply tooling to connect both sides in a controlled way

## Why this is useful
Without an OBS-aware workflow, HomeKit onboarding usually becomes a manual side process:
- HomeKit-facing ioBroker state IDs are created by hand
- existing KNX/ETS-backed OBS datapoints are duplicated instead of reused
- status and write paths drift apart
- naming and room structure become inconsistent across systems
- later restore/fallback work becomes harder to reason about

This PR gives OBS a generic integration pattern for that class of problem:
- use the VISU model as the structural source
- generate stable external state namespaces
- reuse existing datapoints where possible
- preview risky mappings before any productive write happens

## What is included
### API
- `POST /api/v1/homekit/preview`
- `POST /api/v1/homekit/apply`

### Preview
The preview analyzes an existing VISU tree and returns a reviewable HomeKit/Yahka mapping plan including:
- rooms and accessories derived from the VISU hierarchy
- normalized ioBroker state IDs
- intended HomeKit service type
- explicit read/write binding direction
- reuse candidates for existing KNX/ETS datapoints
- warnings for unsupported widgets or risky mappings
- estimated bridge pressure / accessory count

### Apply
The apply step is designed as a migration helper, not as a blind importer:
- dry-run first by default
- reuse existing KNX/ETS-backed OBS datapoints where possible
- only create missing OBS datapoints when truly needed
- create ioBroker bindings for generated HomeKit-facing state IDs
- optionally create the corresponding ioBroker states through the native ioBroker adapter
- stay idempotent where possible

### Current widget scope
- `Licht` -> `Lightbulb`
- `Toggle` -> `Switch` / `Outlet`
- `Fenster` -> `ContactSensor`
- `Rolladen` -> `WindowCovering`
- `RTR` -> `Thermostat`
- `ValueDisplay` -> temperature / humidity sensors where detectable

## Why this is a separate PR
I am intentionally keeping this separate from the native ioBroker adapter work.

The ioBroker adapter itself provides transport, subscriptions, read/write access, and state creation. This PR builds an experimental workflow on top of that foundation. Keeping both changes separate should make review easier and avoids mixing core adapter work with a migration-oriented feature layer.

## Design choices
- reuse before create
- preview before write
- explicit binding direction
- stable naming
- neutral defaults suitable for upstream

The implementation was cleaned up so the core code and docs do not carry installation-specific defaults such as local hostnames, room names, or IP addresses.

## Tests
Validated locally with:
- `ruff format obs/api/router.py obs/api/v1/homekit.py obs/homekit tests/unit/test_homekit_yahka.py`
- `ruff check --fix obs/api/router.py obs/api/v1/homekit.py obs/homekit tests/unit/test_homekit_yahka.py`
- `pytest tests/unit/test_homekit_yahka.py`

Local result:
- `7 passed`

## Docs
Included in this PR:
- English overview for owners/reviewers
- German overview
- preview/apply flow documentation

## Not in scope
This PR does not try to:
- replace Yahka
- manage HomeKit pairing/HAP identities from OBS
- become a full Apple Home editor in the OBS GUI
- hide fallback/restore concerns behind magic defaults

A future GUI would most naturally live close to the adapter configuration, e.g.:
- `Adapter -> ioBroker -> HomeKit/Yahka`

## Notes
This is marked experimental on purpose. The intent is to make the migration and planning workflow reviewable and useful without claiming that every HomeKit/Yahka operational detail already belongs inside OBS.
