### PR TITLE
fix(widgets): set explicit x-axis min/max to remove left/right gaps i…

### DIFF
--- a/frontend/src/widgets/Chart/Widget.vue
+++ b/frontend/src/widgets/Chart/Widget.vue
@@ -31,15 +31,19 @@ function fmtMs(ms: number): string {
 async function loadData() {
   if (!props.datapointId || props.editorMode) return
   const now = new Date()
-  const from = new Date(now.getTime() - hours.value * 3_600_000).toISOString()
-  const data = await history.query(props.datapointId, from, now.toISOString())
+  const fromDate = new Date(now.getTime() - hours.value * 3_600_000)
+  const data = await history.query(props.datapointId, fromDate.toISOString(), now.toISOString())
 
   const points = data.map((d) => ({ x: new Date(d.ts).getTime(), y: Number(d.v) }))
   currentUnit = data[0]?.u ?? ''
 
   if (chart) {
     chart.data.datasets[0].data = points
-    // Update Y-axis title with unit if available
+    const xAxis = chart.options.scales?.x as any
+    if (xAxis) {
+      xAxis.min = fromDate.getTime()
+      xAxis.max = now.getTime()
+    }
     const yAxis = chart.options.scales?.y as any
     if (yAxis) {
       yAxis.title = { display: !!currentUnit, text: currentUnit, color: '#6b7280', font: { size: 11 } }

--- a/frontend/src/widgets/ValueDisplay/Widget.vue
+++ b/frontend/src/widgets/ValueDisplay/Widget.vue
@@ -195,18 +195,24 @@ function makeDataset(color: string) {
 }
 
 async function fetchPoints() {
-  if (!props.datapointId || props.editorMode) return []
-  const now  = new Date()
-  const from = new Date(now.getTime() - historyHours.value * 3_600_000).toISOString()
-  const data = await history.query(props.datapointId, from, now.toISOString())
+  if (!props.datapointId || props.editorMode) return { pts: [], minMs: 0, maxMs: 0 }
+  const now     = new Date()
+  const fromDate = new Date(now.getTime() - historyHours.value * 3_600_000)
+  const data    = await history.query(props.datapointId, fromDate.toISOString(), now.toISOString())
   histUnit = data[0]?.u ?? ''
-  return data.map(d => ({ x: new Date(d.ts).getTime(), y: Number(d.v) }))
+  return {
+    pts:   data.map(d => ({ x: new Date(d.ts).getTime(), y: Number(d.v) })),
+    minMs: fromDate.getTime(),
+    maxMs: now.getTime(),
+  }
 }
 
 async function updateMiniChart() {
   if (mode.value !== 'history' || !miniChart) return
-  const pts = await fetchPoints()
+  const { pts, minMs, maxMs } = await fetchPoints()
   miniChart.data.datasets[0].data = pts
+  const xAxis = miniChart.options.scales?.x as any
+  if (xAxis) { xAxis.min = minMs; xAxis.max = maxMs }
   miniChart.update()
 }
 
@@ -233,7 +239,7 @@ watch(modalOpen, async (open) => {
   if (!open) { modalChart?.destroy(); modalChart = null; return }
   await new Promise<void>(r => setTimeout(r, 50))
   if (!modalCanvasEl.value) return
-  const pts = await fetchPoints()
+  const { pts, minMs, maxMs } = await fetchPoints()
   modalChart = new Chart(modalCanvasEl.value, {
     type: 'line',
     data: { datasets: [{ ...makeDataset(activeColor.value), data: pts }] },
@@ -252,6 +258,8 @@ watch(modalOpen, async (open) => {
       scales: {
         x: {
           type: 'linear',
+          min: minMs,
+          max: maxMs,
           ticks: { color: '#6b7280', maxTicksLimit: 6, maxRotation: 0, callback: (ms: any) => fmtMs(Number(ms)) },
           grid: { color: '#1f2937' },
         },


### PR DESCRIPTION
…n history charts

Chart.js added automatic padding around data points when no bounds were set. Now loadData()/fetchPoints() pass the exact time window (from→now) as min/max to the x-axis so the data fills the full chart width. Fixes #237.