### PR TITLE
Fix logic for time-based value handling and improve tests

### DIFF
--- a/obs/logic/executor.py
+++ b/obs/logic/executor.py
@@ -617,12 +617,7 @@ class GraphExecutor:
                     state["last_value"] = fval
 
                     # Tagesmittel berechnen sobald alle drei Slots das gleiche Datum tragen
-                    if (
-                        state["t1_date"] == today
-                        and state["t2_date"] == today
-                        and state["t3_date"] == today
-                        and state["daily_avg_date"] != today
-                    ):
+                    if state["t1_date"] == today and state["t2_date"] == today and state["t3_date"] == today and state["daily_avg_date"] != today:
                         daily_avg = (state["t1"] + state["t2"] + 2 * state["t3"]) / 4
                         state["daily_avg"] = daily_avg
                         state["daily_avg_date"] = today

--- a/obs/logic/executor.py
+++ b/obs/logic/executor.py
@@ -549,8 +549,15 @@ class GraphExecutor:
 
             case "heating_circuit":
                 # DIN-Norm Sommer/Winter-Umschaltung mit Hysterese
-                # Eingang: Temperaturwert (wird je nach Tageszeit T1/T2/T3 zugeordnet)
-                # T1 ≈ 07:00, T2 ≈ 14:00, T3 ≈ 22:00 (doppelt gewichtet)
+                # Eingang: Aussentemperatur (kontinuierlicher Datenpunkt, keine Zeitschaltuhr nötig).
+                # Der Block puffert den zuletzt empfangenen Wert und übernimmt ihn als Slot-Wert
+                # in dem Moment, in dem die Uhr genau die Zielstunde erreicht:
+                #   T1 = "anliegender Wert" bei Stunde 7  (07:xx Uhr)
+                #   T2 = "anliegender Wert" bei Stunde 12 (12:xx Uhr)
+                #   T3 = "anliegender Wert" bei Stunde 22 (22:xx Uhr)
+                # "anliegender Wert" = letzter bekannter Wert zum Zeitpunkt des Übergangs,
+                # d.h. wenn um 07:05 ein Wert eintrifft, wird last_value (06:55-Wert) als T1 gespeichert.
+                # Jeder Slot wird pro Tag nur EINMAL erfasst; Folgewerte werden verworfen.
                 # T_avg = (T1 + T2 + 2×T3) / 4
                 # heating_mode=1 wenn ref_temp < temp_winter, bleibt 1 bis ref_temp > temp_summer
                 import datetime as _dt
@@ -558,6 +565,7 @@ class GraphExecutor:
                 state = self.hysteresis_state.setdefault(
                     node.id,
                     {
+                        "last_value": None,
                         "t1": None,
                         "t1_date": None,
                         "t2": None,
@@ -566,47 +574,75 @@ class GraphExecutor:
                         "t3_date": None,
                         "daily_temps": [],
                         "daily_avg": None,
+                        "daily_avg_date": None,
                         "monthly_avg": None,
                         "heating_mode": 0,
                     },
                 )
+                # Migrate states persisted before these fields were introduced
+                state.setdefault("last_value", None)
+                state.setdefault("daily_avg_date", None)
+
                 val = inputs.get("value")
                 temp_winter = float(d.get("temp_winter", 15.0))
                 temp_summer = float(d.get("temp_summer", 20.0))
                 if val is not None:
                     fval = self._to_num(val)
-                    today = _dt.date.today().isoformat()
-                    # _slot allows unit tests to force a specific slot without mocking time
+                    # _date / _hour allow unit tests to override wall-clock without mocking
+                    today = inputs.get("_date") or _dt.date.today().isoformat()
                     slot = inputs.get("_slot")
-                    if slot is None:
-                        hour = _dt.datetime.now().hour
-                        if 5 <= hour <= 10:
-                            slot = "t1"
-                        elif 12 <= hour <= 16:
-                            slot = "t2"
-                        elif 20 <= hour <= 23:
-                            slot = "t3"
+
                     if slot in ("t1", "t2", "t3"):
+                        # Test-Override: Slot direkt mit dem eingehenden Wert belegen
                         state[slot] = fval
                         state[f"{slot}_date"] = today
-                    # Compute daily avg once all three slots have today's date
-                    if state["t1_date"] == today and state["t2_date"] == today and state["t3_date"] == today:
+                    elif state["daily_avg_date"] != today:
+                        # "Anliegender Wert"-Logik: T1/T2/T3 = last_value beim Überqueren der
+                        # Zielstunde.  Ist noch kein last_value vorhanden (erster Wert des Tages),
+                        # wird der aktuelle Wert als bestmögliche Näherung verwendet.
+                        hour = inputs.get("_hour", _dt.datetime.now().hour)
+                        capture_val = state["last_value"] if state["last_value"] is not None else fval
+                        if hour == 7 and state["t1_date"] != today:
+                            state["t1"] = capture_val
+                            state["t1_date"] = today
+                        elif hour == 12 and state["t2_date"] != today:
+                            state["t2"] = capture_val
+                            state["t2_date"] = today
+                        elif hour == 22 and state["t3_date"] != today:
+                            state["t3"] = capture_val
+                            state["t3_date"] = today
+
+                    # last_value nach dem Slot-Check aktualisieren, damit beim NÄCHSTEN
+                    # Zeitpunkt der gerade empfangene Wert als "anliegender Wert" dient.
+                    state["last_value"] = fval
+
+                    # Tagesmittel berechnen sobald alle drei Slots das gleiche Datum tragen
+                    if (
+                        state["t1_date"] == today
+                        and state["t2_date"] == today
+                        and state["t3_date"] == today
+                        and state["daily_avg_date"] != today
+                    ):
                         daily_avg = (state["t1"] + state["t2"] + 2 * state["t3"]) / 4
                         state["daily_avg"] = daily_avg
+                        state["daily_avg_date"] = today
                         state["daily_temps"].append(daily_avg)
                         state["daily_temps"] = state["daily_temps"][-31:]
                         state["monthly_avg"] = sum(state["daily_temps"]) / len(state["daily_temps"])
-                        # Reset slots for next day
+                        # Slots für den nächsten Tag zurücksetzen
                         for k in ("t1", "t2", "t3", "t1_date", "t2_date", "t3_date"):
                             state[k] = None
-                # Hysteresis: switch ON below temp_winter, OFF above temp_summer
+                # Hysterese: EIN wenn < temp_winter, AUS wenn > temp_summer
                 ref_temp = state["monthly_avg"] if state["monthly_avg"] is not None else state["daily_avg"]
                 if ref_temp is not None:
                     if ref_temp < temp_winter:
                         state["heating_mode"] = 1
                     elif ref_temp > temp_summer:
                         state["heating_mode"] = 0
-                    # between thresholds: keep last state (hysteresis)
+                    # zwischen den Schwellwerten: letzten Zustand beibehalten (Hysterese)
+                elif val is not None:
+                    # Noch keine Historik: Modus sofort aus dem aktuellen Wert ableiten
+                    state["heating_mode"] = 1 if self._to_num(val) < temp_winter else 0
                 return {
                     "heating_mode": state["heating_mode"],
                     "daily_avg": state["daily_avg"],

--- a/obs/logic/node_types.py
+++ b/obs/logic/node_types.py
@@ -372,9 +372,13 @@ BUILTIN_NODE_TYPES: list[NodeTypeDef] = [
         category="math",
         description=(
             "Sommer/Winter-Umschaltung nach DIN. Eingang: Aussentemperatur. "
-            "Der Wert wird je nach Tageszeit automatisch T1 (≈07:00), T2 (≈14:00) oder T3 (≈22:00) zugeordnet. "
+            "Messungen werden exakten Tageszeitpunkten zugeordnet: "
+            "T1 = Messung um 07:00 Uhr (Stunde 7), T2 = Messung um 12:00 Uhr (Stunde 12), T3 = Messung um 22:00 Uhr (Stunde 22). "
+            "Messungen zu anderen Uhrzeiten werden verworfen. Jeder Slot wird pro Tag nur einmal erfasst. "
             "Tagesmittel: T_avg = (T1 + T2 + 2×T3) / 4. "
-            "Heizmodus ON wenn Mittelwert < Temp. Winter, bleibt ON bis Mittelwert > Temp. Sommer (Hysterese)."
+            "Monatsmittel: gleitender Mittelwert der letzten 31 Tagesmittel. "
+            "Heizmodus ON wenn Mittelwert < Temp. Winter, bleibt ON bis Mittelwert > Temp. Sommer (Hysterese). "
+            "Ohne gespeicherte Historik wird der Modus sofort aus der aktuellen Temperatur abgeleitet."
         ),
         inputs=[
             _port("value", "Temp °C"),

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -1031,7 +1031,7 @@ class TestHeatingCircuit:
     def test_hysteresis_stays_on_between_thresholds(self):
         """Once ON, heating stays ON when temp is between winter and summer."""
         state = {}
-        self._run_full_day(5, 6, 4, state=state, date=self._d(0))   # cold → ON
+        self._run_full_day(5, 6, 4, state=state, date=self._d(0))  # cold → ON
         out, _ = self._run_full_day(17, 18, 17, state=state, date=self._d(1))  # mild → stays ON
         assert out["heating_mode"] == 1
 
@@ -1074,9 +1074,9 @@ class TestHeatingCircuit:
         06:55 value that was on the bus at 07:00), NOT 5.5.
         """
         state = {}
-        self._run_at_hour(6, 5.0, state=state)   # 06:xx → stored as last_value
+        self._run_at_hour(6, 5.0, state=state)  # 06:xx → stored as last_value
         out, _ = self._run_at_hour(7, 5.5, state=state)  # 07:xx crosses target
-        assert out["t1"] == pytest.approx(5.0)   # last_value, NOT 5.5
+        assert out["t1"] == pytest.approx(5.0)  # last_value, NOT 5.5
 
     def test_t1_uses_fval_when_no_prior_value(self):
         """If no prior measurement exists, the first 07:xx reading becomes T1."""
@@ -1104,10 +1104,10 @@ class TestHeatingCircuit:
     def test_t2_uses_last_value_at_1200_boundary(self):
         """T2 = value present at 12:00 (last_value from hour 11)."""
         state = {}
-        self._run_at_hour(7, 5.0, state=state)    # T1 captured; last_value=5.0
+        self._run_at_hour(7, 5.0, state=state)  # T1 captured; last_value=5.0
         self._run_at_hour(11, 12.0, state=state)  # 11:xx → no slot, last_value=12.0
         out, _ = self._run_at_hour(12, 12.5, state=state)  # 12:xx crosses target
-        assert out["t2"] == pytest.approx(12.0)   # last_value (11:xx), NOT 12.5
+        assert out["t2"] == pytest.approx(12.0)  # last_value (11:xx), NOT 12.5
 
     def test_t2_not_captured_at_hour_11(self):
         """Measurement at hour 11 must not fill T2."""
@@ -1124,9 +1124,9 @@ class TestHeatingCircuit:
     def test_t3_uses_last_value_at_2200_boundary(self):
         """T3 = value present at 22:00 (last_value from earlier)."""
         state = {}
-        self._run_at_hour(21, 7.0, state=state)   # 21:xx → no slot, last_value=7.0
+        self._run_at_hour(21, 7.0, state=state)  # 21:xx → no slot, last_value=7.0
         out, _ = self._run_at_hour(22, 7.5, state=state)  # 22:xx crosses target
-        assert out["t3"] == pytest.approx(7.0)    # last_value (21:xx), NOT 7.5
+        assert out["t3"] == pytest.approx(7.0)  # last_value (21:xx), NOT 7.5
 
     def test_t3_not_captured_at_hour_21(self):
         """Measurement at hour 21 must not fill T3."""
@@ -1143,11 +1143,11 @@ class TestHeatingCircuit:
         daily_avg = (10.0 + 14.0 + 2×8.0) / 4 = 10.0
         """
         state = {}
-        self._run_at_hour(6, 10.0, state=state)   # last_value before T1
-        self._run_at_hour(7, 10.5, state=state)   # T1 = 10.0 (last_value)
+        self._run_at_hour(6, 10.0, state=state)  # last_value before T1
+        self._run_at_hour(7, 10.5, state=state)  # T1 = 10.0 (last_value)
         self._run_at_hour(11, 14.0, state=state)  # last_value before T2
         self._run_at_hour(12, 14.2, state=state)  # T2 = 14.0 (last_value)
-        self._run_at_hour(21, 8.0, state=state)   # last_value before T3
+        self._run_at_hour(21, 8.0, state=state)  # last_value before T3
         out, _ = self._run_at_hour(22, 8.1, state=state)  # T3 = 8.0, daily computed
         assert out["daily_avg"] == pytest.approx(10.0)
 
@@ -1167,7 +1167,7 @@ class TestHeatingCircuit:
     def test_initial_heating_mode_below_winter_threshold(self):
         """With no historical data, first measurement below temp_winter → ON."""
         state = {}
-        out, _ = self._run_slot("t1", 5.0, state=state)   # 5 < 15
+        out, _ = self._run_slot("t1", 5.0, state=state)  # 5 < 15
         assert out["heating_mode"] == 1
 
     def test_initial_heating_mode_above_winter_threshold(self):

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -946,19 +946,37 @@ class TestGateNode:
 
 
 class TestHeatingCircuit:
-    """Tests for the redesigned heating_circuit node.
+    """Tests for the heating_circuit node (Sommer/Winter DIN).
 
-    New API: single 'value' input; time slot assigned via '_slot' override
-    (t1 / t2 / t3).  All three slots in the same date must be received
-    before a daily_avg is computed.
-    Hysteresis: heating ON when ref_temp < temp_winter, OFF when > temp_summer,
-    stays unchanged between thresholds.
+    Single 'value' input.  Slot assignment uses fixed time points:
+      T1 = first measurement at hour >= 7
+      T2 = first measurement at hour >= 12
+      T3 = first measurement at hour >= 22
+    Each slot is filled ONCE per day; subsequent readings in the same
+    time range are discarded.
+
+    Test overrides injected via the inputs dict:
+      _slot  – bypass time logic and force a specific slot (t1/t2/t3)
+      _hour  – override wall-clock hour for time-based slot assignment
+      _date  – override wall-clock date (ISO string) for multi-day scenarios
+
+    Hysteresis: ON when ref_temp < temp_winter, OFF when > temp_summer,
+    unchanged between thresholds.
+    Without historical data the first measurement initialises heating_mode
+    directly: < temp_winter → ON, >= temp_winter → OFF.
     """
 
     # Default: heating ON below 15 °C, OFF above 20 °C
     _CFG = {"temp_winter": 15.0, "temp_summer": 20.0}
 
-    def _run_slot(self, slot, value, config=None, state=None):
+    @staticmethod
+    def _d(day: int) -> str:
+        """ISO date string for day N (0 = 2025-01-01), used to simulate multiple days."""
+        from datetime import date, timedelta
+
+        return (date(2025, 1, 1) + timedelta(days=day)).isoformat()
+
+    def _run_slot(self, slot, value, config=None, state=None, date="2025-01-01"):
         """Feed a single temperature reading at the given time slot."""
         if state is None:
             state = {}
@@ -966,9 +984,9 @@ class TestHeatingCircuit:
             config = self._CFG
         n1 = node("h", "heating_circuit", config)
         exc = make_executor([n1], hysteresis_state=state)
-        return exc.execute({"h": {"value": value, "_slot": slot}})["h"], state
+        return exc.execute({"h": {"value": value, "_slot": slot, "_date": date}})["h"], state
 
-    def _run_full_day(self, t1, t2, t3, config=None, state=None):
+    def _run_full_day(self, t1, t2, t3, config=None, state=None, date="2025-01-01"):
         """Simulate a full day (all three slots) and return the final output."""
         if state is None:
             state = {}
@@ -978,8 +996,20 @@ class TestHeatingCircuit:
         out = None
         for slot, val in [("t1", t1), ("t2", t2), ("t3", t3)]:
             exc = make_executor([n1], hysteresis_state=state)
-            out = exc.execute({"h": {"value": val, "_slot": slot}})["h"]
+            out = exc.execute({"h": {"value": val, "_slot": slot, "_date": date}})["h"]
         return out, state
+
+    def _run_at_hour(self, hour, value, config=None, state=None, date="2025-01-01"):
+        """Feed a temperature with a specific hour override (tests time-based slot logic)."""
+        if state is None:
+            state = {}
+        if config is None:
+            config = self._CFG
+        n1 = node("h", "heating_circuit", config)
+        exc = make_executor([n1], hysteresis_state=state)
+        return exc.execute({"h": {"value": value, "_hour": hour, "_date": date}})["h"], state
+
+    # ── DIN-Formel ────────────────────────────────────────────────────────────
 
     def test_din_formula_daily_avg(self):
         # T_avg = (10 + 12 + 2*8) / 4 = 38/4 = 9.5
@@ -996,37 +1026,163 @@ class TestHeatingCircuit:
         out, _ = self._run_full_day(22, 24, 22)
         assert out["heating_mode"] == 0
 
+    # ── Hysterese ─────────────────────────────────────────────────────────────
+
     def test_hysteresis_stays_on_between_thresholds(self):
         """Once ON, heating stays ON when temp is between winter and summer."""
         state = {}
-        # Cold day → heating ON
-        self._run_full_day(5, 6, 4, state=state)
-        # Mild day (17 °C avg) — between 15 and 20 → must stay ON
-        out, _ = self._run_full_day(17, 18, 17, state=state)
+        self._run_full_day(5, 6, 4, state=state, date=self._d(0))   # cold → ON
+        out, _ = self._run_full_day(17, 18, 17, state=state, date=self._d(1))  # mild → stays ON
         assert out["heating_mode"] == 1
 
     def test_hysteresis_stays_off_between_thresholds(self):
         """Once OFF, heating stays OFF when temp is between thresholds."""
         state = {}
-        # Warm day → heating OFF
-        self._run_full_day(22, 24, 22, state=state)
-        # Mild day (17 °C avg) — between 15 and 20 → must stay OFF
-        out, _ = self._run_full_day(17, 18, 17, state=state)
+        self._run_full_day(22, 24, 22, state=state, date=self._d(0))  # warm → OFF
+        out, _ = self._run_full_day(17, 18, 17, state=state, date=self._d(1))  # mild → stays OFF
         assert out["heating_mode"] == 0
 
     def test_hysteresis_turns_off_above_temp_summer(self):
         """Heating turns OFF once monthly_avg rises above temp_summer.
 
-        After 1 cold day (avg≈4.75) we need ≥7 warm days (avg≈22.5) so that
-        the rolling monthly average exceeds temp_summer=20 °C.
+        1 cold day (avg=4.75) + 9 warm days (avg=22.5):
+        monthly_avg after day 10 = (4.75 + 9×22.5) / 10 = 20.725 > 20 → OFF.
         """
         state = {}
-        self._run_full_day(5, 6, 4, state=state)  # cold day → ON
-        # 9 warm days: monthly_avg ≈ (4.75 + 9×22.5) / 10 = 206.75/10 = 20.675 > 20
-        for _ in range(9):
-            self._run_full_day(22, 24, 22, state=state)
-        out, _ = self._run_full_day(22, 24, 22, state=state)  # 10th warm → OFF
+        self._run_full_day(5, 6, 4, state=state, date=self._d(0))  # cold → ON
+        for i in range(9):
+            self._run_full_day(22, 24, 22, state=state, date=self._d(i + 1))
+        out, _ = self._run_full_day(22, 24, 22, state=state, date=self._d(10))
         assert out["heating_mode"] == 0
+
+    # ── Anliegender Wert / exakte Zeitpunkte (gemeldeter Bug) ────────────────
+
+    def test_value_at_0600_updates_last_value_only(self):
+        """A measurement before 07:00 updates last_value but fills no slot."""
+        state = {}
+        out, _ = self._run_at_hour(6, 10.0, state=state)
+        assert out["t1"] is None
+        assert out["t2"] is None
+        assert out["t3"] is None
+
+    def test_t1_uses_last_value_at_0700_boundary(self):
+        """T1 = the value that was PRESENT at 07:00 (last_value), not the
+        triggering measurement.
+
+        Sensor sends at 06:55 (5.0 °C) and again at 07:05 (5.5 °C).
+        At 07:05 the block sees hour==7 for the first time → T1 = 5.0 (the
+        06:55 value that was on the bus at 07:00), NOT 5.5.
+        """
+        state = {}
+        self._run_at_hour(6, 5.0, state=state)   # 06:xx → stored as last_value
+        out, _ = self._run_at_hour(7, 5.5, state=state)  # 07:xx crosses target
+        assert out["t1"] == pytest.approx(5.0)   # last_value, NOT 5.5
+
+    def test_t1_uses_fval_when_no_prior_value(self):
+        """If no prior measurement exists, the first 07:xx reading becomes T1."""
+        state = {}
+        out, _ = self._run_at_hour(7, 10.0, state=state)
+        assert out["t1"] == pytest.approx(10.0)
+
+    def test_t1_not_captured_at_hour_9(self):
+        """Measurement at hour 9 must NOT fill T1 (the reported bug).
+
+        The old implementation used a window 5–10 h, so 09:50 could overwrite
+        the 07:00 value.  With exact time-point logic only hour==7 triggers T1.
+        """
+        state = {}
+        out, _ = self._run_at_hour(9, 15.0, state=state)
+        assert out["t1"] is None
+
+    def test_t1_not_overwritten_by_second_reading_at_hour_7(self):
+        """Once T1 is captured, a further reading during hour 7 is ignored."""
+        state = {}
+        self._run_at_hour(7, 10.0, state=state)
+        out, _ = self._run_at_hour(7, 15.0, state=state)  # same hour → no change
+        assert out["t1"] == pytest.approx(10.0)
+
+    def test_t2_uses_last_value_at_1200_boundary(self):
+        """T2 = value present at 12:00 (last_value from hour 11)."""
+        state = {}
+        self._run_at_hour(7, 5.0, state=state)    # T1 captured; last_value=5.0
+        self._run_at_hour(11, 12.0, state=state)  # 11:xx → no slot, last_value=12.0
+        out, _ = self._run_at_hour(12, 12.5, state=state)  # 12:xx crosses target
+        assert out["t2"] == pytest.approx(12.0)   # last_value (11:xx), NOT 12.5
+
+    def test_t2_not_captured_at_hour_11(self):
+        """Measurement at hour 11 must not fill T2."""
+        state = {}
+        out, _ = self._run_at_hour(11, 13.0, state=state)
+        assert out["t2"] is None
+
+    def test_t2_not_captured_at_hour_13(self):
+        """Measurement at hour 13 must not fill T2 (only hour==12 is valid)."""
+        state = {}
+        out, _ = self._run_at_hour(13, 13.0, state=state)
+        assert out["t2"] is None
+
+    def test_t3_uses_last_value_at_2200_boundary(self):
+        """T3 = value present at 22:00 (last_value from earlier)."""
+        state = {}
+        self._run_at_hour(21, 7.0, state=state)   # 21:xx → no slot, last_value=7.0
+        out, _ = self._run_at_hour(22, 7.5, state=state)  # 22:xx crosses target
+        assert out["t3"] == pytest.approx(7.0)    # last_value (21:xx), NOT 7.5
+
+    def test_t3_not_captured_at_hour_21(self):
+        """Measurement at hour 21 must not fill T3."""
+        state = {}
+        out, _ = self._run_at_hour(21, 8.0, state=state)
+        assert out["t3"] is None
+
+    def test_full_day_via_exact_time_points_computes_daily_avg(self):
+        """Full day: last_value at 07:00, 12:00, 22:00 → daily_avg computed.
+
+        Pre-07:00 value = 10.0, triggers at 07:xx with 10.5 → T1=10.0
+        Pre-12:00 value = 14.0, triggers at 12:xx with 14.2 → T2=14.0
+        Pre-22:00 value = 8.0,  triggers at 22:xx with 8.1  → T3=8.0
+        daily_avg = (10.0 + 14.0 + 2×8.0) / 4 = 10.0
+        """
+        state = {}
+        self._run_at_hour(6, 10.0, state=state)   # last_value before T1
+        self._run_at_hour(7, 10.5, state=state)   # T1 = 10.0 (last_value)
+        self._run_at_hour(11, 14.0, state=state)  # last_value before T2
+        self._run_at_hour(12, 14.2, state=state)  # T2 = 14.0 (last_value)
+        self._run_at_hour(21, 8.0, state=state)   # last_value before T3
+        out, _ = self._run_at_hour(22, 8.1, state=state)  # T3 = 8.0, daily computed
+        assert out["daily_avg"] == pytest.approx(10.0)
+
+    def test_no_double_daily_avg_same_day(self):
+        """After the daily avg is computed for a date, further readings on the
+        same date must not append a second entry to daily_temps."""
+        state = {}
+        # First full day: daily_temps gains one entry
+        self._run_full_day(10, 14, 8, state=state, date="2025-06-01")
+        count_after_day1 = len(state["h"]["daily_temps"])
+        # Simulate late-night reading on the same date via _slot override
+        self._run_slot("t3", 9.0, state=state, date="2025-06-01")
+        assert len(state["h"]["daily_temps"]) == count_after_day1  # no second entry
+
+    # ── Initialzustand ohne Historik ──────────────────────────────────────────
+
+    def test_initial_heating_mode_below_winter_threshold(self):
+        """With no historical data, first measurement below temp_winter → ON."""
+        state = {}
+        out, _ = self._run_slot("t1", 5.0, state=state)   # 5 < 15
+        assert out["heating_mode"] == 1
+
+    def test_initial_heating_mode_above_winter_threshold(self):
+        """With no historical data, first measurement >= temp_winter → OFF."""
+        state = {}
+        out, _ = self._run_slot("t1", 18.0, state=state)  # 18 >= 15
+        assert out["heating_mode"] == 0
+
+    def test_initial_heating_mode_exactly_at_winter_threshold(self):
+        """Exactly at temp_winter (15 °C) → summer mode (no heating needed)."""
+        state = {}
+        out, _ = self._run_slot("t1", 15.0, state=state)
+        assert out["heating_mode"] == 0
+
+    # ── Mehrere Tage / Debug-Ausgaben ─────────────────────────────────────────
 
     def test_debug_outputs_visible_before_day_complete(self):
         """t1/t2/t3 debug ports reflect stored slot values."""
@@ -1039,21 +1195,19 @@ class TestHeatingCircuit:
 
     def test_monthly_avg_after_multiple_days(self):
         state = {}
-        # Day 1: T_avg = (4+6+2*2)/4 = 14/4 = 3.5
-        self._run_full_day(4, 6, 2, state=state)
-        # Day 2: T_avg = (8+10+2*6)/4 = 30/4 = 7.5
-        out, _ = self._run_full_day(8, 10, 6, state=state)
-        # monthly_avg = (3.5 + 7.5) / 2 = 5.5
+        # Day 1: T_avg = (4+6+2*2)/4 = 3.5
+        self._run_full_day(4, 6, 2, state=state, date=self._d(0))
+        # Day 2: T_avg = (8+10+2*6)/4 = 7.5
+        out, _ = self._run_full_day(8, 10, 6, state=state, date=self._d(1))
         assert out["monthly_avg"] == pytest.approx(5.5)
 
     def test_heating_mode_uses_monthly_avg(self):
-        """When monthly_avg is available it determines heating_mode, not daily_avg."""
+        """When monthly_avg is available it drives heating_mode, not daily_avg."""
         state = {}
-        # Build up warm monthly average (>20 °C → above temp_summer → OFF)
-        for _ in range(3):
-            self._run_full_day(22, 24, 22, state=state)  # daily_avg ≈ 22.5
-        # Now send a cold day — monthly_avg is still warm → heating stays OFF
-        out, _ = self._run_full_day(5, 6, 4, state=state)
+        for i in range(3):
+            self._run_full_day(22, 24, 22, state=state, date=self._d(i))  # daily_avg ≈ 22.5
+        # Cold day: daily_avg < temp_winter, but monthly_avg is warm → stays OFF
+        out, _ = self._run_full_day(5, 6, 4, state=state, date=self._d(3))
         assert out["heating_mode"] == 0
 
     def test_no_input_returns_default_heating_mode(self):
@@ -1066,8 +1220,8 @@ class TestHeatingCircuit:
 
     def test_monthly_buffer_capped_at_31_days(self):
         state = {}
-        for _ in range(40):  # push 40 days
-            self._run_full_day(10, 12, 8, state=state)
+        for i in range(40):
+            self._run_full_day(10, 12, 8, state=state, date=self._d(i))
         assert len(state["h"]["daily_temps"]) <= 31
 
 


### PR DESCRIPTION
last_value-Puffer: T1/T2/T3 = letzter bekannter Wert beim Ueberqueren von Stunde 7/12/22 Messungen zu anderen Uhrzeiten werden verworfen (Fix Bug: 09:50 wurde faelschlicherweise als T1 gespeichert)
daily_avg_date-Guard verhindert doppeltes Eintragen desselben Tages
Ohne Historik: Initialzustand sofort aus aktueller Temperatur ableiten
State-Migration: last_value und daily_avg_date per setdefault rueckwaertskompatibel
Tests: _date/_hour-Overrides fuer Mehrtagessimulation; 15+ neue Tests