### PR TITLE
Unblock ioBroker browse/import when status lags

### DIFF
--- a/obs/api/v1/adapters.py
+++ b/obs/api/v1/adapters.py
@@ -581,7 +581,7 @@ async def iobroker_browse_states(
         raise HTTPException(status.HTTP_400_BAD_REQUEST, "Nur für IOBROKER-Instanzen verfügbar")
 
     instance = adapter_registry.get_instance_by_id(str(instance_id))
-    if instance is None or not getattr(instance, "connected", False):
+    if instance is None:
         raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, "ioBroker-Instanz ist nicht verbunden")
     if not hasattr(instance, "browse_states"):
         raise HTTPException(status.HTTP_501_NOT_IMPLEMENTED, "ioBroker-State-Browser nicht verfügbar")
@@ -647,7 +647,7 @@ async def _iobroker_candidates(
     db: Database,
 ) -> list[IoBrokerImportItem]:
     instance = adapter_registry.get_instance_by_id(instance_id)
-    if instance is None or not getattr(instance, "connected", False):
+    if instance is None:
         raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, "ioBroker-Instanz ist nicht verbunden")
     states = await instance.browse_states(body.prefix, min(max(body.limit, 1), 500))
     selected = set(body.states)

--- a/tests/unit/test_iobroker_adapters_api.py
+++ b/tests/unit/test_iobroker_adapters_api.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from obs.api.v1 import adapters as adapters_api
+from obs.api.v1.adapters import IoBrokerImportRequest
+
+
+class _FakeDb:
+    def __init__(self, row: dict, binding_rows: list[dict] | None = None):
+        self._row = row
+        self._binding_rows = binding_rows or []
+
+    async def fetchone(self, _query: str, _params: tuple):
+        return self._row
+
+    async def fetchall(self, query: str, _params: tuple):
+        if "FROM adapter_bindings" in query:
+            return self._binding_rows
+        return []
+
+
+@pytest.mark.asyncio
+async def test_browse_states_uses_running_instance_even_if_connected_flag_is_false(
+    monkeypatch,
+):
+    fake_instance = type("FakeIoBrokerInstance", (), {})()
+    fake_instance.connected = False
+    fake_instance.browse_states = AsyncMock(
+        return_value=[
+            {
+                "id": "hue.0.Küche_3.on",
+                "name": "Küche 3 On",
+                "type": "boolean",
+                "role": "switch.light",
+                "read": True,
+                "write": True,
+                "value": False,
+                "unit": None,
+            }
+        ]
+    )
+
+    monkeypatch.setattr(
+        adapters_api.adapter_registry,
+        "get_instance_by_id",
+        lambda _instance_id: fake_instance,
+    )
+
+    result = await adapters_api.iobroker_browse_states(
+        instance_id="96f4d53c-455d-47ff-a9d0-a9def24951ff",
+        q="Küche",
+        limit=10,
+        _user="admin",
+        db=_FakeDb({"adapter_type": "IOBROKER"}),
+    )
+
+    assert len(result) == 1
+    assert result[0].id == "hue.0.Küche_3.on"
+    fake_instance.browse_states.assert_awaited_once_with("Küche", 10)
+
+
+@pytest.mark.asyncio
+async def test_import_preview_uses_running_instance_even_if_connected_flag_is_false(
+    monkeypatch,
+):
+    fake_instance = type("FakeIoBrokerInstance", (), {})()
+    fake_instance.connected = False
+    fake_instance.browse_states = AsyncMock(
+        return_value=[
+            {
+                "id": "0_userdata.0.obs.home.eg.kueche.licht.on",
+                "name": "Küche Licht",
+                "type": "boolean",
+                "role": "switch.light",
+                "read": True,
+                "write": True,
+                "value": False,
+                "unit": None,
+            }
+        ]
+    )
+
+    monkeypatch.setattr(
+        adapters_api.adapter_registry,
+        "get_instance_by_id",
+        lambda _instance_id: fake_instance,
+    )
+
+    result = await adapters_api.iobroker_import_preview(
+        instance_id="96f4d53c-455d-47ff-a9d0-a9def24951ff",
+        body=IoBrokerImportRequest(
+            prefix="Küche",
+            direction="auto",
+            tags=["eg", "kueche"],
+            limit=10,
+        ),
+        _user="admin",
+        db=_FakeDb({"adapter_type": "IOBROKER"}),
+    )
+
+    assert len(result.preview) == 1
+    assert result.preview[0].state_id == "0_userdata.0.obs.home.eg.kueche.licht.on"
+    assert result.preview[0].exists is False
+    fake_instance.browse_states.assert_awaited_once_with("Küche", 10)


### PR DESCRIPTION
## Summary

This PR restores the ioBroker binding workflow when the adapter status lags behind the live Socket.IO connection.

In the affected state, the runtime can already be connected and subscribed again, while the adapter API still reports `connected = false`. The Binding dialog then treats the instance as disconnected and blocks:

- `GET /api/v1/adapters/instances/{id}/iobroker/states`
- `POST /api/v1/adapters/instances/{id}/iobroker/import-preview`

As a result, users cannot browse ioBroker states or create new bindings even though the live adapter path is already working again.

## Root cause

The browse/import endpoints were gated too strictly by `instance.connected`.

That flag is currently not reliable in every recovery situation, so the UI could be blocked even though:

- the Socket.IO transport was already back
- subscriptions were already active
- existing data paths could already work again

## Fix

For the ioBroker browse/import endpoints, only require that the adapter instance exists in the registry.

If a running instance is available, call `browse_states(...)` directly and let the live call fail naturally if the ioBroker path is actually unavailable.

This keeps the fix intentionally small:

- no change to the deeper adapter status bookkeeping yet
- no change to the transport or reconnect logic
- only the workflow-blocking gate is relaxed

## Tests

Added unit tests covering both affected paths:

- `iobroker/states` works with a running instance whose `connected` flag is `false`
- `iobroker/import-preview` works with a running instance whose `connected` flag is `false`

Closes #282
