### PR TITLE
Update RELEASENOTES.md for version 2026.5.1-RC2

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,5 +1,19 @@
 # Changes
 
+## 2026.5.1-RC2
+### New features:
+* none
+
+### Fixes:
+* Fix used tags at docker images https://github.com/abeggled/openbridgeserver/pull/323 (the real reason for 2026.5.1-RC2)
+* ioBroker browse/import preview are blocked when the instance status lags behind the live socket connection https://github.com/abeggled/openbridgeserver/issues/282
+* History give only last 1000 entries https://github.com/abeggled/openbridgeserver/issues/316
+* Enhancment Roof Window Widget (new Velux-Type) https://github.com/abeggled/openbridgeserver/issues/317
+* Sommer/Winter Umschaltung nach DIN Functional Block does not work as expected https://github.com/abeggled/openbridgeserver/issues/311
+
+### Breaking changes:
+* none
+
 ## 2026.4.4
 ### New features:
 * Initial release


### PR DESCRIPTION
Added release notes for version 2026.5.1-RC2, including new features, fixes, and breaking changes.