### PR TITLE
Pin python-socketio below v5 for ioBroker compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ holidays>=0.95
 httpx>=0.28.1
 websockets>=16.0
 # ioBroker socketio v7 still speaks Engine.IO v3; python-socketio v4 is compatible.
-python-socketio[asyncio_client]>=5.16.1,<6
+python-socketio[asyncio_client]>=4.6,<5
 
 # History plugins — optional, install only the backend(s) you use:
 asyncpg>=0.31.0         # TimescaleDB / PostgreSQL history plugin


### PR DESCRIPTION
## Summary

This PR restores the previous Socket.IO client compatibility range for the native ioBroker adapter.

## Why

`requirements.txt` was updated to:

- `python-socketio[asyncio_client]>=5.16.1,<6`

At the same time, the file still documents:

- `ioBroker socketio v7 still speaks Engine.IO v3; python-socketio v4 is compatible.`

In a real MM12/CM5 setup, current `main` fails to establish the live ioBroker connection and repeatedly logs:

- `ioBroker Socket.IO connection failed`
- `OPEN packet not returned by server`

We verified in the same OBS container that:

- `python-socketio 5.16.1` fails against the ioBroker endpoint
- a temporary `python-socketio 4.6.1` client connects successfully immediately

## Change

Pin the dependency back to the v4-compatible range:

- `python-socketio[asyncio_client]>=4.6,<5`

This matches the existing inline comment and restores the behavior that works with ioBroker `socket.io/web` v7 style deployments.

## Scope

This is intentionally a minimal compatibility fix:

- no adapter code changes
- no reconnect logic changes
- only the dependency pin is corrected

## Validation

- reproduced the connection failure on current `main`
- verified successful connection with a v4 client in the same container environment
- `pytest tests/adapters/test_iobroker.py` -> `21 passed`

Refs #326
