### PR TITLE
Reflect live ioBroker socket state in adapter status

### DIFF
--- a/obs/adapters/iobroker/adapter.py
+++ b/obs/adapters/iobroker/adapter.py
@@ -138,6 +138,20 @@ class IoBrokerAdapter(AdapterBase):
         self._connect_url: str | None = None
         self._connect_kwargs: dict[str, Any] = {}
 
+    def _socket_is_connected(self) -> bool:
+        if self._socket is None:
+            return False
+        if getattr(self._socket, "connected", False):
+            return True
+        engineio_client = getattr(self._socket, "eio", None)
+        return getattr(engineio_client, "state", None) == "connected"
+
+    @property
+    def connected(self) -> bool:
+        if self._socket_is_connected():
+            return True
+        return self._connected
+
     async def connect(self) -> None:
         try:
             import socketio
@@ -294,9 +308,9 @@ class IoBrokerAdapter(AdapterBase):
             if self._socket is not sio:
                 return
             logger.info("ioBroker Socket.IO connected → %s", self._connect_url)
-            subscribed = await self._subscribe_bound_states(force_publish_initial=True)
-            if subscribed and self._cfg is not None:
+            if self._cfg is not None:
                 await self._publish_status(True, f"Verbunden mit {self._cfg.host}:{self._cfg.port}")
+            await self._subscribe_bound_states(force_publish_initial=True)
 
         @sio.event
         async def disconnect():  # noqa: ANN202
@@ -337,7 +351,7 @@ class IoBrokerAdapter(AdapterBase):
     async def _reconnect_loop(self) -> None:
         assert self._cfg is not None
         while not self._disconnect_requested:
-            if self._socket and getattr(self._socket, "connected", False):
+            if self._socket_is_connected():
                 return
             connected = await self._connect_socket()
             if connected:
@@ -345,14 +359,16 @@ class IoBrokerAdapter(AdapterBase):
             await asyncio.sleep(self._cfg.reconnect_interval_seconds)
 
     async def _subscribe_bound_states(self, *, force_publish_initial: bool = True) -> bool:
-        if not self._socket or not getattr(self._socket, "connected", False) or not self._state_map:
-            return bool(self._socket and getattr(self._socket, "connected", False))
+        if not self._socket_is_connected() or not self._state_map:
+            return self._socket_is_connected()
 
         async with self._subscription_lock:
             states = list(self._state_map.keys())
             try:
                 await self._call_socket("subscribe", states)
                 logger.info("ioBroker Socket.IO subscribed: %s", states)
+                if self._cfg is not None:
+                    await self._publish_status(True, f"Verbunden mit {self._cfg.host}:{self._cfg.port}")
             except Exception:
                 logger.exception("ioBroker Socket.IO subscribe failed")
                 await self._publish_status(False, "Subscribe fehlgeschlagen")
@@ -373,7 +389,7 @@ class IoBrokerAdapter(AdapterBase):
         return True
 
     async def _call_socket(self, event: str, *args: Any, timeout: float = 10.0) -> Any:
-        if not self._socket or not getattr(self._socket, "connected", False):
+        if not self._socket or not self._socket_is_connected():
             raise RuntimeError("ioBroker Socket.IO is not connected")
         if not args:
             data = None

--- a/tests/adapters/test_iobroker.py
+++ b/tests/adapters/test_iobroker.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from obs.core.event_bus import AdapterStatusEvent, DataValueEvent
 from tests.adapters.conftest import make_binding
 from obs.adapters.iobroker.adapter import IoBrokerAdapter, _coerce_iobroker_value
 
@@ -67,6 +68,13 @@ class TestCallSocket:
 
         with pytest.raises(RuntimeError):
             await adapter._call_socket("getState", "foo")
+
+    def test_connected_property_uses_engineio_state(self, adapter):
+        adapter._socket.connected = False
+        adapter._socket.eio = MagicMock()
+        adapter._socket.eio.state = "connected"
+
+        assert adapter.connected is True
 
 
 class TestRead:
@@ -145,6 +153,10 @@ class TestStateChange:
 
 
 class TestSubscribe:
+    @staticmethod
+    def _data_events(mock_bus):
+        return [call.args[0] for call in mock_bus.publish.await_args_list if isinstance(call.args[0], DataValueEvent)]
+
     @pytest.mark.asyncio
     async def test_subscribe_uses_state_list_and_initial_read(self, adapter, mock_bus):
         binding = make_binding({"state_id": "0_userdata.0.temp"})
@@ -162,7 +174,7 @@ class TestSubscribe:
             "subscribe",
             ["0_userdata.0.temp"],
         )
-        event = mock_bus.publish.call_args[0][0]
+        event = self._data_events(mock_bus)[-1]
         assert event.value == pytest.approx(22.0)
 
     @pytest.mark.asyncio
@@ -181,7 +193,7 @@ class TestSubscribe:
         await adapter._subscribe_bound_states(force_publish_initial=True)
         await adapter._subscribe_bound_states(force_publish_initial=False)
 
-        assert mock_bus.publish.call_count == 1
+        assert len(self._data_events(mock_bus)) == 1
 
     @pytest.mark.asyncio
     async def test_watchdog_resync_publishes_changed_initial_values(self, adapter, mock_bus):
@@ -199,8 +211,8 @@ class TestSubscribe:
         await adapter._subscribe_bound_states(force_publish_initial=True)
         await adapter._subscribe_bound_states(force_publish_initial=False)
 
-        assert mock_bus.publish.call_count == 2
-        event = mock_bus.publish.call_args[0][0]
+        assert len(self._data_events(mock_bus)) == 2
+        event = self._data_events(mock_bus)[-1]
         assert event.value == pytest.approx(23.0)
 
     @pytest.mark.asyncio
@@ -217,7 +229,27 @@ class TestSubscribe:
         await adapter._subscribe_bound_states(force_publish_initial=True)
         await adapter._on_state_change_event("0_userdata.0.light", {"val": True})
 
-        assert mock_bus.publish.call_count == 1
+        assert len(self._data_events(mock_bus)) == 1
+
+    @pytest.mark.asyncio
+    async def test_subscribe_marks_connected_when_engineio_is_connected(self, adapter, mock_bus):
+        binding = make_binding({"state_id": "0_userdata.0.temp"})
+        adapter._state_map["0_userdata.0.temp"] = [binding]
+        adapter._socket.connected = False
+        adapter._socket.eio = MagicMock()
+        adapter._socket.eio.state = "connected"
+        adapter._socket.call = AsyncMock(
+            side_effect=[
+                [None, None],
+                [None, {"val": 22.0}],
+            ]
+        )
+
+        await adapter._subscribe_bound_states(force_publish_initial=True)
+
+        status_events = [call.args[0] for call in mock_bus.publish.await_args_list if isinstance(call.args[0], AdapterStatusEvent)]
+        assert status_events
+        assert status_events[-1].connected is True
 
 
 class TestReconnect:


### PR DESCRIPTION
## Summary

This PR fixes a stale ioBroker adapter status where the live Socket.IO connection is already working again, but the adapter still reports `connected = false` and stays yellow in the UI.

## Problem

In the observed MM12/CM5 setup, after the ioBroker path recovered we saw:

- OBS logs: `ioBroker Socket.IO connected`
- OBS logs: `ioBroker Socket.IO subscribed`
- read/write and switching worked again
- but the adapter badge still showed `Läuft` instead of `Verbunden`

The root cause is that the adapter status relied too narrowly on `socket.connected` / `_connected`, while the live Engine.IO session could already be connected again.

## What changed

- add `_socket_is_connected()` to evaluate the live Socket.IO/Engine.IO state
- expose `connected` via that live socket state first, falling back to `_connected`
- mark the adapter as connected immediately on successful `connect`
- also mark it as connected after a successful subscribe/resubscribe
- use the live socket check in reconnect and call paths

## Why this is intentionally small

This PR does not change the adapter protocol logic or binding behavior.
It only makes the runtime status reflect the actual live connection more accurately.

## Validation

Local:

- `ruff format obs/adapters/iobroker/adapter.py tests/adapters/test_iobroker.py`
- `ruff check --fix obs/adapters/iobroker/adapter.py tests/adapters/test_iobroker.py`
- `pytest tests/adapters/test_iobroker.py`
- result: `23 passed`

MM12 runtime test:

- ioBroker connections recovered successfully
- OBS logs showed `connected` and `subscribed`
- `/api/v1/system/health` reported `adapters_running: 2`
- switching/read-write still worked

This is effectively the follow-up for the stale yellow-status behavior behind the earlier ioBroker recovery issues.
