### PR TITLE
feat: propagate DataPoint renames into logic graph nodes

### DIFF
--- a/obs/api/v1/logic.py
+++ b/obs/api/v1/logic.py
@@ -214,6 +214,14 @@ async def import_graph(
     known_types = {nt.type for nt in list_node_types()}
 
     # Unbekannte Node-Typen → missing_node Platzhalter
+    # Bekannte Nodes: datapoint_name aus aktuellem Objektsystem holen
+    try:
+        from obs.core.registry import get_registry
+
+        _registry = get_registry()
+    except Exception:
+        _registry = None
+
     processed_nodes: list[LogicNode] = []
     for node in body.flow_data.nodes:
         if node.type not in known_types and node.type != "missing_node":
@@ -229,6 +237,13 @@ async def import_graph(
                 ),
             )
         else:
+            if _registry is not None and "datapoint_id" in node.data:
+                try:
+                    dp = _registry.get(uuid.UUID(node.data["datapoint_id"]))
+                    if dp is not None:
+                        node.data["datapoint_name"] = dp.name
+                except Exception:
+                    pass
             processed_nodes.append(node)
 
     processed_flow = FlowData(nodes=processed_nodes, edges=body.flow_data.edges)

--- a/obs/core/event_bus.py
+++ b/obs/core/event_bus.py
@@ -51,8 +51,17 @@ class AdapterStatusEvent:
     ts: datetime = field(default_factory=lambda: datetime.now(UTC))
 
 
+@dataclass
+class DataPointRenamedEvent:
+    """Fired when a DataPoint's name is changed via the registry."""
+
+    dp_id: uuid.UUID
+    old_name: str
+    new_name: str
+
+
 # All event types that the bus understands
-AnyEvent = DataValueEvent | AdapterStatusEvent
+AnyEvent = DataValueEvent | AdapterStatusEvent | DataPointRenamedEvent
 
 Handler = Callable[[AnyEvent], Coroutine[Any, Any, None]]
 

--- a/obs/core/registry.py
+++ b/obs/core/registry.py
@@ -196,6 +196,7 @@ class DataPointRegistry:
         updates = payload.model_dump(exclude_none=True)
         now = datetime.now(UTC)
 
+        old_name = dp.name
         for key, val in updates.items():
             setattr(dp, key, val)
         dp.updated_at = now
@@ -222,6 +223,12 @@ class DataPointRegistry:
 
         self._points[dp_id] = dp
         logger.debug("DataPoint updated: %s (%s)", dp.name, dp_id)
+
+        if dp.name != old_name:
+            from obs.core.event_bus import DataPointRenamedEvent
+
+            await self._bus.publish(DataPointRenamedEvent(dp_id=dp_id, old_name=old_name, new_name=dp.name))
+
         return dp
 
     async def delete(self, dp_id: uuid.UUID) -> None:

--- a/obs/logic/manager.py
+++ b/obs/logic/manager.py
@@ -80,16 +80,18 @@ class LogicManager:
         """Subscribe to EventBus, load all graphs and start cron schedulers."""
         await self._load_app_config()
         await self._load_graphs()
-        from obs.core.event_bus import DataValueEvent
+        from obs.core.event_bus import DataPointRenamedEvent, DataValueEvent
 
         self._event_bus.subscribe(DataValueEvent, self._on_value_event)
+        self._event_bus.subscribe(DataPointRenamedEvent, self._on_datapoint_renamed)
         self._start_cron_tasks()
         logger.info("LogicManager started — %d graphs loaded", len(self._graphs))
 
     async def stop(self) -> None:
-        from obs.core.event_bus import DataValueEvent
+        from obs.core.event_bus import DataPointRenamedEvent, DataValueEvent
 
         self._event_bus.unsubscribe(DataValueEvent, self._on_value_event)
+        self._event_bus.unsubscribe(DataPointRenamedEvent, self._on_datapoint_renamed)
         for task in self._cron_tasks.values():
             task.cancel()
         self._cron_tasks.clear()
@@ -256,6 +258,30 @@ class LogicManager:
             if not overrides:
                 continue
             await self._execute_graph(graph_id, name, flow, overrides)
+
+    async def _on_datapoint_renamed(self, event: Any) -> None:
+        """Update datapoint_name in all logic nodes that reference the renamed DataPoint."""
+        dp_id_str = str(event.dp_id)
+        for graph_id, (name, enabled, flow) in self._graphs.items():
+            changed = False
+            for node in flow.nodes:
+                if node.data.get("datapoint_id") == dp_id_str and node.data.get("datapoint_name") != event.new_name:
+                    node.data["datapoint_name"] = event.new_name
+                    changed = True
+            if changed:
+                try:
+                    await self._db.execute_and_commit(
+                        "UPDATE logic_graphs SET flow_data=?, updated_at=? WHERE id=?",
+                        (flow.model_dump_json(), datetime.now(UTC).isoformat(), graph_id),
+                    )
+                    logger.info(
+                        "LogicManager: updated datapoint_name '%s' → '%s' in graph %s",
+                        event.old_name,
+                        event.new_name,
+                        graph_id[:8],
+                    )
+                except Exception as exc:
+                    logger.warning("LogicManager: failed to persist renamed datapoint in graph %s: %s", graph_id[:8], exc)
 
     # ── Execution ─────────────────────────────────────────────────────────
 

--- a/tests/integration/test_logic_rename.py
+++ b/tests/integration/test_logic_rename.py
@@ -147,9 +147,7 @@ async def test_import_resolves_datapoint_name_from_registry(client, auth_headers
 
         graph = await _get_graph(client, auth_headers, graph_id)
         node_data = graph["flow_data"]["nodes"][0]["data"]
-        assert node_data["datapoint_name"] == f"IT-Import-Current-{ts}", (
-            f"Expected current registry name, got '{node_data['datapoint_name']}'"
-        )
+        assert node_data["datapoint_name"] == f"IT-Import-Current-{ts}", f"Expected current registry name, got '{node_data['datapoint_name']}'"
 
     finally:
         await _cleanup(client, auth_headers, graph_ids=[graph_id] if graph_id else [], dp_ids=[dp_id])

--- a/tests/integration/test_logic_rename.py
+++ b/tests/integration/test_logic_rename.py
@@ -1,0 +1,155 @@
+"""Integration tests — DataPoint rename propagation into logic graphs (issue #333).
+
+Verifies that:
+  1. Renaming a DataPoint via PATCH /api/v1/datapoints/{id} immediately updates
+     datapoint_name in all logic graph nodes that reference it.
+  2. Importing a logic graph resolves datapoint_name from the current registry,
+     discarding any stale name stored in the export JSON.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# Helpers (duplicated locally for isolation)
+# ---------------------------------------------------------------------------
+
+
+async def _create_dp(client, auth_headers, name: str) -> dict:
+    resp = await client.post(
+        "/api/v1/datapoints/",
+        json={"name": name, "data_type": "FLOAT", "tags": []},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+async def _create_graph(client, auth_headers, name: str, nodes: list, edges: list | None = None) -> str:
+    resp = await client.post(
+        "/api/v1/logic/graphs",
+        json={"name": name, "description": "", "enabled": True, "flow_data": {"nodes": nodes, "edges": edges or []}},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+async def _get_graph(client, auth_headers, graph_id: str) -> dict:
+    resp = await client.get(f"/api/v1/logic/graphs/{graph_id}", headers=auth_headers)
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+async def _cleanup(client, auth_headers, graph_ids: list[str] | None = None, dp_ids: list[str] | None = None) -> None:
+    for gid in graph_ids or []:
+        await client.delete(f"/api/v1/logic/graphs/{gid}", headers=auth_headers)
+    for did in dp_ids or []:
+        await client.delete(f"/api/v1/datapoints/{did}", headers=auth_headers)
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — Rename propagation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rename_datapoint_updates_logic_graph_nodes(client, auth_headers):
+    """PATCH datapoint name → datapoint_name in all referencing logic nodes updated."""
+    ts = time.time()
+    dp = await _create_dp(client, auth_headers, f"IT-Rename-Before-{ts}")
+    dp_id = dp["id"]
+    graph_id = None
+
+    try:
+        graph_id = await _create_graph(
+            client,
+            auth_headers,
+            f"IT-Rename-Graph-{ts}",
+            [
+                {
+                    "id": "r1",
+                    "type": "datapoint_read",
+                    "position": {"x": 0, "y": 0},
+                    "data": {"datapoint_id": dp_id, "datapoint_name": f"IT-Rename-Before-{ts}"},
+                },
+                {
+                    "id": "w1",
+                    "type": "datapoint_write",
+                    "position": {"x": 200, "y": 0},
+                    "data": {"datapoint_id": dp_id, "datapoint_name": f"IT-Rename-Before-{ts}"},
+                },
+            ],
+        )
+
+        new_name = f"IT-Rename-After-{ts}"
+        rename_resp = await client.patch(
+            f"/api/v1/datapoints/{dp_id}",
+            json={"name": new_name},
+            headers=auth_headers,
+        )
+        assert rename_resp.status_code == 200, rename_resp.text
+
+        graph = await _get_graph(client, auth_headers, graph_id)
+        nodes = graph["flow_data"]["nodes"]
+        names = [n["data"].get("datapoint_name") for n in nodes]
+        assert all(n == new_name for n in names), f"Expected all nodes to have '{new_name}', got {names}"
+
+    finally:
+        await _cleanup(client, auth_headers, graph_ids=[graph_id] if graph_id else [], dp_ids=[dp_id])
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — Import resolves name from current registry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_import_resolves_datapoint_name_from_registry(client, auth_headers):
+    """Import uses the current registry name, ignoring the stale name in the JSON."""
+    ts = time.time()
+    dp = await _create_dp(client, auth_headers, f"IT-Import-Current-{ts}")
+    dp_id = dp["id"]
+    graph_id = None
+
+    try:
+        import_payload = {
+            "obs_export": "logic_graph",
+            "version": 1,
+            "name": f"IT-Import-Rename-{ts}",
+            "description": "",
+            "enabled": True,
+            "flow_data": {
+                "nodes": [
+                    {
+                        "id": "r1",
+                        "type": "datapoint_read",
+                        "position": {"x": 0, "y": 0},
+                        "data": {
+                            "datapoint_id": dp_id,
+                            "datapoint_name": "STALE_NAME_FROM_EXPORT",
+                        },
+                    }
+                ],
+                "edges": [],
+            },
+        }
+
+        import_resp = await client.post("/api/v1/logic/graphs/import", json=import_payload, headers=auth_headers)
+        assert import_resp.status_code == 201, import_resp.text
+        graph_id = import_resp.json()["id"]
+
+        graph = await _get_graph(client, auth_headers, graph_id)
+        node_data = graph["flow_data"]["nodes"][0]["data"]
+        assert node_data["datapoint_name"] == f"IT-Import-Current-{ts}", (
+            f"Expected current registry name, got '{node_data['datapoint_name']}'"
+        )
+
+    finally:
+        await _cleanup(client, auth_headers, graph_ids=[graph_id] if graph_id else [], dp_ids=[dp_id])

--- a/tests/unit/test_logic_rename.py
+++ b/tests/unit/test_logic_rename.py
@@ -1,0 +1,146 @@
+"""Unit tests for DataPoint rename propagation into logic graphs (issue #333).
+
+Verifies that:
+  - _on_datapoint_renamed updates datapoint_name in all graph nodes that reference
+    the renamed DataPoint and persists the change to the DB.
+  - Nodes that reference a different DataPoint are not touched.
+  - Nodes already carrying the correct name are not re-written.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from obs.core.event_bus import DataPointRenamedEvent
+from obs.logic.manager import LogicManager
+from obs.logic.models import FlowData
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_manager(graphs: dict) -> tuple[LogicManager, MagicMock]:
+    """Return a LogicManager with an in-memory graph cache and a tracked DB mock."""
+    db = MagicMock()
+    db.execute_and_commit = AsyncMock()
+    event_bus = MagicMock()
+    registry = MagicMock()
+
+    mgr = LogicManager(db, event_bus, registry)
+    mgr._graphs = graphs
+    return mgr, db
+
+
+def _flow_with_nodes(*nodes_data: dict) -> FlowData:
+    nodes = [
+        {
+            "id": f"n{i}",
+            "type": "datapoint_read",
+            "position": {"x": 0, "y": 0},
+            "data": nd,
+        }
+        for i, nd in enumerate(nodes_data)
+    ]
+    return FlowData.model_validate({"nodes": nodes, "edges": []})
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rename_updates_matching_node():
+    dp_id = uuid.uuid4()
+    flow = _flow_with_nodes({"datapoint_id": str(dp_id), "datapoint_name": "Alt"})
+    mgr, db = _make_manager({"g1": ("MyGraph", True, flow)})
+
+    event = DataPointRenamedEvent(dp_id=dp_id, old_name="Alt", new_name="Neu")
+    await mgr._on_datapoint_renamed(event)
+
+    assert flow.nodes[0].data["datapoint_name"] == "Neu"
+    db.execute_and_commit.assert_awaited_once()
+    call_args = db.execute_and_commit.call_args[0]
+    assert "UPDATE logic_graphs" in call_args[0]
+    saved_flow = json.loads(call_args[1][0])
+    assert saved_flow["nodes"][0]["data"]["datapoint_name"] == "Neu"
+
+
+@pytest.mark.asyncio
+async def test_rename_leaves_unrelated_node_unchanged():
+    dp_id = uuid.uuid4()
+    other_id = uuid.uuid4()
+    flow = _flow_with_nodes(
+        {"datapoint_id": str(other_id), "datapoint_name": "Unrelated"},
+    )
+    mgr, db = _make_manager({"g1": ("MyGraph", True, flow)})
+
+    event = DataPointRenamedEvent(dp_id=dp_id, old_name="Alt", new_name="Neu")
+    await mgr._on_datapoint_renamed(event)
+
+    assert flow.nodes[0].data["datapoint_name"] == "Unrelated"
+    db.execute_and_commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_rename_skips_node_already_up_to_date():
+    dp_id = uuid.uuid4()
+    flow = _flow_with_nodes({"datapoint_id": str(dp_id), "datapoint_name": "Neu"})
+    mgr, db = _make_manager({"g1": ("MyGraph", True, flow)})
+
+    event = DataPointRenamedEvent(dp_id=dp_id, old_name="Alt", new_name="Neu")
+    await mgr._on_datapoint_renamed(event)
+
+    db.execute_and_commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_rename_updates_multiple_graphs_and_nodes():
+    dp_id = uuid.uuid4()
+    flow1 = _flow_with_nodes(
+        {"datapoint_id": str(dp_id), "datapoint_name": "Alt"},
+        {"datapoint_id": str(dp_id), "datapoint_name": "Alt"},
+    )
+    flow2 = _flow_with_nodes({"datapoint_id": str(dp_id), "datapoint_name": "Alt"})
+    mgr, db = _make_manager({"g1": ("G1", True, flow1), "g2": ("G2", True, flow2)})
+
+    event = DataPointRenamedEvent(dp_id=dp_id, old_name="Alt", new_name="Neu")
+    await mgr._on_datapoint_renamed(event)
+
+    assert flow1.nodes[0].data["datapoint_name"] == "Neu"
+    assert flow1.nodes[1].data["datapoint_name"] == "Neu"
+    assert flow2.nodes[0].data["datapoint_name"] == "Neu"
+    assert db.execute_and_commit.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_rename_handles_node_without_datapoint_id():
+    """Nodes that have no datapoint_id (e.g. math nodes) must not be touched."""
+    dp_id = uuid.uuid4()
+    flow = FlowData.model_validate(
+        {
+            "nodes": [
+                {"id": "m1", "type": "math_formula", "position": {"x": 0, "y": 0}, "data": {"formula": "a+b"}},
+                {
+                    "id": "r1",
+                    "type": "datapoint_read",
+                    "position": {"x": 0, "y": 0},
+                    "data": {"datapoint_id": str(dp_id), "datapoint_name": "Alt"},
+                },
+            ],
+            "edges": [],
+        }
+    )
+    mgr, db = _make_manager({"g1": ("G1", True, flow)})
+
+    event = DataPointRenamedEvent(dp_id=dp_id, old_name="Alt", new_name="Neu")
+    await mgr._on_datapoint_renamed(event)
+
+    assert flow.nodes[1].data["datapoint_name"] == "Neu"
+    db.execute_and_commit.assert_awaited_once()


### PR DESCRIPTION
## Summary

- Umbenennung eines Objekts wird sofort in allen referenzierenden Logik-Graph-Nodes übernommen (in Memory + DB)
- Import eines Logikblatts verwendet den aktuellen Namen aus dem Objektsystem, nicht den veralteten Namen aus dem JSON

## Changes

### `obs/core/event_bus.py`
Neues `DataPointRenamedEvent` mit `dp_id`, `old_name`, `new_name`

### `obs/core/registry.py`
`registry.update()` feuert `DataPointRenamedEvent` wenn der Name sich ändert

### `obs/logic/manager.py`
`LogicManager` abonniert `DataPointRenamedEvent` — `_on_datapoint_renamed()` scannt alle Graphen nach Nodes mit passender `datapoint_id`, setzt `datapoint_name` und persistiert in DB (nur wenn tatsächlich geändert)

### `obs/api/v1/logic.py`
Import-Endpoint löst `datapoint_name` aus aktuellem Registry auf (überschreibt veralteten Namen aus dem Export-JSON)

## Tests

- **5 Unit-Tests** (`tests/unit/test_logic_rename.py`): Rename-Propagation, unberührte Nodes, mehrere Graphen, Nodes ohne `datapoint_id`
- **2 Integrationstests** (`tests/integration/test_logic_rename.py`): API-Rename propagiert in Graph, Import löst Namen korrekt auf

## Branch Protection Checklist

- [x] Unit tests pass (5/5)
- [x] Integration tests pass (require Docker/Mosquitto)

Closes #333