### PR TITLE
[codex] Refresh adapter instance status in Adapters view

### DIFF
--- a/gui/src/views/AdaptersView.vue
+++ b/gui/src/views/AdaptersView.vue
@@ -273,7 +273,7 @@
 </template>
 
 <script setup>
-import { ref, reactive, computed, onMounted } from 'vue'
+import { ref, reactive, computed, onMounted, onBeforeUnmount } from 'vue'
 import { adapterApi } from '@/api/client'
 import { useAdapterStore } from '@/stores/adapters'
 import { useAuthStore } from '@/stores/auth'
@@ -328,15 +328,35 @@ const allImportSelected = computed(() => {
   return selectable.length > 0 && selectable.every(id => selectedImportStates.value.includes(id))
 })
 
+let refreshTimer = null
+
 // ------------------------------------------------------------------
 
-onMounted(async () => {
+async function refreshInstances() {
   await store.fetchAdapters()
   initDrafts()
+  for (const a of store.instances) {
+    const fb = feedback[a.id]
+    if (a.connected && fb && fb.success === false) {
+      delete feedback[a.id]
+    }
+  }
+}
+
+onMounted(async () => {
+  await refreshInstances()
   try {
     availableTypes.value = await store.fetchTypes()
   } catch {
     availableTypesErr.value = true
+  }
+  refreshTimer = window.setInterval(refreshInstances, 10000)
+})
+
+onBeforeUnmount(() => {
+  if (refreshTimer) {
+    window.clearInterval(refreshTimer)
+    refreshTimer = null
   }
 })
 
@@ -437,6 +457,7 @@ async function testConnection(a) {
   try {
     const result = await store.testInstance(a.id, drafts[a.id].config)
     feedback[a.id] = result
+    await refreshInstances()
   } catch (e) {
     feedback[a.id] = { success: false, detail: e.response?.data?.detail ?? 'Fehler' }
   } finally {
@@ -456,6 +477,7 @@ async function saveInstance(a) {
       enabled: drafts[a.id].enabled,
     })
     feedback[a.id] = { success: true, detail: 'Gespeichert und neu verbunden' }
+    await refreshInstances()
   } catch (e) {
     feedback[a.id] = { success: false, detail: e.response?.data?.detail ?? 'Fehler' }
   } finally {
@@ -471,6 +493,7 @@ async function restartInstance(a) {
   try {
     await store.restartInstance(a.id)
     feedback[a.id] = { success: true, detail: 'Verbindung neu aufgebaut' }
+    await refreshInstances()
   } catch (e) {
     feedback[a.id] = { success: false, detail: e.response?.data?.detail ?? 'Fehler' }
   } finally {


### PR DESCRIPTION
## Summary

This PR makes the Admin GUI refresh adapter instance status while the Adapters view is open.

## Problem

The backend now reports the live ioBroker connection state more accurately after the recent status fix, but the Adapters view only loaded adapter instances when the page was mounted. If an adapter recovered in the background, or if a manual test/save/reconnect changed the runtime state shortly after the action returned, the visible badge could stay stale until the user manually reloaded the page.

In practice this could leave the ioBroker row showing `Läuft` instead of `Verbunden`, and the import button could remain disabled even though the backend already considered the instance connected.

## What changed

- Added a small `refreshInstances()` helper in `gui/src/views/AdaptersView.vue`.
- Replaced the initial one-time `store.fetchAdapters()` call with `refreshInstances()`.
- Started a 10-second refresh timer while the Adapters view is mounted.
- Cleared the timer in `onBeforeUnmount()`.
- Refreshed adapter instances immediately after connection test, save, and reconnect actions.
- Cleared stale failure feedback once a refreshed instance reports `connected = true`.

## How this fixes it

The GUI now periodically asks the existing adapter API for the current instance list instead of relying on the initial page state. Once the backend updates an adapter from running/disconnected to connected, the row badge and connection-dependent actions update without a browser reload.

This is intentionally limited to the Adapters view. It does not change adapter protocol logic, ioBroker connection handling, or backend status computation.

## Validation

- `npm --prefix gui install --no-package-lock`
- `npm --prefix gui run build`

Result: GUI production build completed successfully.
