### PR TITLE
fix: prevent false-positive red exclamation mark in Link/WidgetRef/Ro…

### DIFF
--- a/frontend/src/widgets/Link/index.ts
+++ b/frontend/src/widgets/Link/index.ts
@@ -14,4 +14,5 @@ WidgetRegistry.register({
   defaultConfig: { label: '', icon: '🔗', target_node_id: '' },
   compatibleTypes: ['*'],
   noDatapoint: true,
+  getExtraDatapointIds: () => [],
 })

--- a/frontend/src/widgets/Rolladen/index.ts
+++ b/frontend/src/widgets/Rolladen/index.ts
@@ -38,6 +38,9 @@ WidgetRegistry.register({
   noDatapoint: true,
   getExtraDatapointIds: (config) => {
     return [
+      config.dp_move_up as string,
+      config.dp_move_down as string,
+      config.dp_stop as string,
       config.dp_position as string,
       config.dp_position_status as string,
       config.dp_slat as string,

--- a/frontend/src/widgets/WidgetRef/index.ts
+++ b/frontend/src/widgets/WidgetRef/index.ts
@@ -15,4 +15,5 @@ WidgetRegistry.register({
   compatibleTypes: ['*'],
   noDatapoint: true,
   supportsStatusDatapoint: false,
+  getExtraDatapointIds: () => [],
 })


### PR DESCRIPTION
…lladen widgets (#342)

- Link: add getExtraDatapointIds()=>[] so target_node_id (visu page UUID) is not mistakenly validated as a datapoint reference
- WidgetRef: same fix for source_page_id (visu page UUID)
- Rolladen: add missing dp_move_up/dp_move_down/dp_stop to getExtraDatapointIds so those bindings are correctly validated after import